### PR TITLE
Fix WSOD with NodeHeaderBlock when on content type with no body field

### DIFF
--- a/src/Plugin/Block/NodeHeaderBlock.php
+++ b/src/Plugin/Block/NodeHeaderBlock.php
@@ -84,7 +84,7 @@ class NodeHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
       '#title' => $this->node->getTitle(),
     ];
 
-    if (!$this->node->get('body')->isEmpty()) {
+    if ($this->node->hasField('body') && !$this->node->get('body')->isEmpty()) {
       $body = $this->node->get('body')->first()->getValue();
       if ($body and array_key_exists('summary', $body)) {
         $build[0]['#lede'] = [

--- a/tests/src/Functional/BlockTest.php
+++ b/tests/src/Functional/BlockTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\localgov\Functional;
+namespace Drupal\Tests\localgov_core\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 

--- a/tests/src/Functional/BlockTest.php
+++ b/tests/src/Functional/BlockTest.php
@@ -33,11 +33,22 @@ class BlockTest extends BrowserTestBase {
   protected function setUp() {
     parent::setUp();
 
+    // Create a dummy content type that we will use for testing.
+    $type = $this->container->get('entity_type.manager')->getStorage('node_type')
+      ->create([
+        'type' => 'dummy',
+        'name' => 'Dummy',
+      ]);
+    $type->save();
+    $this->container->get('router.builder')->rebuild();
+
     $this->adminUser = $this->drupalCreateUser([
       'access content',
       'administer nodes',
       'create localgov_services_page content',
       'edit own localgov_services_page content',
+      'create dummy content',
+      'edit own dummy content',
     ]);
   }
 
@@ -63,6 +74,24 @@ class BlockTest extends BrowserTestBase {
     $this->assertSession()->pageTextContains($title);
     $this->assertSession()->pageTextContains($summary);
     $this->assertSession()->pageTextContains($body);
+  }
+
+  /**
+   * Test blocks display when content type has no body field.
+   */
+  public function testBlocksDisplayWhenNoSummary() {
+    $this->drupalLogin($this->adminUser);
+
+    // Check node title and summary display on a landing page.
+    $title = $this->randomMachineName(8);
+    $edit = [
+      'title[0][value]' => $title,
+      'status[value]' => 1,
+    ];
+    $this->drupalPostForm('/node/add/dummy', $edit, 'Save');
+    $this->drupalGet('/node/1');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains($title);
   }
 
 }


### PR DESCRIPTION
Fix #6.

Checks that a node has a body field defined before setting a lede.
Adds test to verify.