### PR TITLE
Change block Test not to rely on form submission.

### DIFF
--- a/tests/src/Functional/BlockTest.php
+++ b/tests/src/Functional/BlockTest.php
@@ -13,7 +13,6 @@ use Drupal\Tests\node\Traits\NodeCreationTrait;
 class BlockTest extends BrowserTestBase {
 
   use NodeCreationTrait;
-  use ContentTypeCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -34,22 +33,19 @@ class BlockTest extends BrowserTestBase {
   ];
 
   /**
-   * A user with mininum permissions for test.
-   *
-   * @var \Drupal\user\UserInterface
-   */
-  protected $user;
-
-  /**
    * {@inheritdoc}
    */
   protected function setUp() {
     parent::setUp();
 
-    $this->createContentType(['type' => 'dummy']);
-    $this->user = $this->drupalCreateUser([
-      'access content',
-    ]);
+    // Create a dummy content type that we will use for testing.
+    $type = $this->container->get('entity_type.manager')->getStorage('node_type')
+      ->create([
+        'type' => 'dummy',
+        'name' => 'Dummy',
+      ]);
+    $type->save();
+    $this->container->get('router.builder')->rebuild();
   }
 
   /**


### PR DESCRIPTION
localgovdrupal/localgov_services#36 introduces a new compulsory field
to the localgov_services_page content type, this prevents this test
submitting the form.

Rather than track the form moved to using content creation trait,
with the minimum fields for this test.