### PR TITLE
WYSIWYG text editor and format with Linkit.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "drupal/image_widget_crop": "^2.3"
+        "drupal/image_widget_crop": "^2.3",
+        "drupal/linkit": "^6.0-beta1"
     }
 }

--- a/localgov_core.info.yml
+++ b/localgov_core.info.yml
@@ -6,5 +6,7 @@ core_version_requirement: ^8.8 || ^9
 
 dependencies:
   - drupal:block
+  - drupal:editor
   - drupal:field
   - drupal:node
+  - linkit:linkit

--- a/localgov_core.info.yml
+++ b/localgov_core.info.yml
@@ -6,7 +6,5 @@ core_version_requirement: ^8.8 || ^9
 
 dependencies:
   - drupal:block
-  - drupal:editor
   - drupal:field
   - drupal:node
-  - linkit:linkit

--- a/modules/localgov_media/config/optional/editor.editor.wysiwyg.yml
+++ b/modules/localgov_media/config/optional/editor.editor.wysiwyg.yml
@@ -5,8 +5,6 @@ dependencies:
     - filter.format.wysiwyg
   module:
     - ckeditor
-_core:
-  default_config_hash: gVvqOq7RrzdfNsVJwpcZjnMekiHUt4rw3oYgh8mk6z8
 format: wysiwyg
 editor: ckeditor
 settings:

--- a/modules/localgov_media/config/optional/editor.editor.wysiwyg.yml
+++ b/modules/localgov_media/config/optional/editor.editor.wysiwyg.yml
@@ -1,0 +1,68 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.wysiwyg
+  module:
+    - ckeditor
+_core:
+  default_config_hash: gVvqOq7RrzdfNsVJwpcZjnMekiHUt4rw3oYgh8mk6z8
+format: wysiwyg
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Format
+            - Styles
+            - RemoveFormat
+            - Underline
+            - Bold
+            - Italic
+        -
+          name: Edit
+          items:
+            - Copy
+            - Cut
+            - Paste
+            - Undo
+            - Redo
+        -
+          name: Links
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Media
+          items:
+            - Blockquote
+            - DrupalImage
+            - DrupalMediaLibrary
+        -
+          name: Tools
+          items:
+            - Source
+  plugins:
+    drupallink:
+      linkit_enabled: true
+      linkit_profile: default
+    language:
+      language_list: un
+    stylescombo:
+      styles: "mark|Highlight\r\na.external-link|External link\r\na.pdf-link|PDF link\r\na.btn.btn-start.col-sm-6.mt-3|Start button\r\np.alert.alert-info|Alert info\r\np.alert.alert-danger|Alert warning\r\np.alert.alert-primary|Alert failure\r\np.alert.alert-success|Alert success\r\np.callout.callout-primary|Callout primary\r\np.callout.callout-success|Callout success\r\np.callout.callout-danger|Callout danger\r\np.callout.callout-teal|Callout teal\r\np.callout.callout-carbon|Callout carbon\r\np.callout.callout-yellow|Callout yellow\r\nul.list-checked|Green ticks"
+image_upload:
+  status: false
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: null
+    height: null

--- a/modules/localgov_media/config/optional/filter.format.wysiwyg.yml
+++ b/modules/localgov_media/config/optional/filter.format.wysiwyg.yml
@@ -10,8 +10,6 @@ dependencies:
     - editor
     - linkit
     - media
-_core:
-  default_config_hash: L7IADg1H0VIbgqtzWlkbGGPRZrQk5cHMqat8NyEs5fE
 name: WYSIWYG
 format: wysiwyg
 weight: 0

--- a/modules/localgov_media/config/optional/filter.format.wysiwyg.yml
+++ b/modules/localgov_media/config/optional/filter.format.wysiwyg.yml
@@ -1,0 +1,100 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.medium_8_7
+    - core.entity_view_mode.media.responsive_3x2
+    - core.entity_view_mode.media.scale_crop_7_3_large
+    - core.entity_view_mode.media.square
+  module:
+    - editor
+    - linkit
+    - media
+_core:
+  default_config_hash: L7IADg1H0VIbgqtzWlkbGGPRZrQk5cHMqat8NyEs5fE
+name: WYSIWYG
+format: wysiwyg
+weight: 0
+filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: -44
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -43
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: false
+    weight: -40
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: -49
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: false
+    weight: -41
+    settings:
+      filter_url_length: 72
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: false
+    weight: -42
+    settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -47
+    settings:
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ol type start> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class="alert alert-info alert-danger alert-primary alert-success callout callout-primary callout-success callout-danger callout-teal callout-carbon callout-yellow"> <h1> <pre> <mark> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title class="external-link pdf-link btn btn-start col-sm-6 mt-3"> <ul type class="list-checked"> <u> <img src alt data-entity-type data-entity-uuid data-align data-caption> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: -48
+    settings: {  }
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -45
+    settings: {  }
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: -50
+    settings:
+      title: true
+  media_embed:
+    id: media_embed
+    provider: media
+    status: true
+    weight: -46
+    settings:
+      default_view_mode: responsive_3x2
+      allowed_media_types:
+        document: document
+        image: image
+        remote_video: remote_video
+      allowed_view_modes:
+        default: default
+        medium_8_7: medium_8_7
+        responsive_3x2: responsive_3x2
+        scale_crop_7_3_large: scale_crop_7_3_large
+        square: square

--- a/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
+++ b/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: default
+label: Default
+description: 'A default Linkit profile'
+matchers:
+  556010a3-e317-48b3-b4ed-854c10f4b950:
+    uuid: 556010a3-e317-48b3-b4ed-854c10f4b950
+    id: 'entity:node'
+    weight: 0
+    settings:
+      metadata: ''
+      bundles: {  }
+      group_by_bundle: true
+      include_unpublished: false
+      substitution_type: canonical
+      limit: 100

--- a/modules/localgov_media/localgov_media.info.yml
+++ b/modules/localgov_media/localgov_media.info.yml
@@ -5,6 +5,8 @@ type: module
 core_version_requirement: ^8.8 || ^9
 
 dependencies:
-- drupal:media_library
-- drupal:responsive_image
-- image_widget_crop:image_widget_crop
+  - drupal:editor
+  - drupal:media_library
+  - drupal:responsive_image
+  - image_widget_crop:image_widget_crop
+  - linkit:linkit

--- a/modules/localgov_media/localgov_media.install
+++ b/modules/localgov_media/localgov_media.install
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Install file for the localgov_media module.
+ */
+
+use Drupal\user\Entity\Role;
+
+/**
+ * Implements hook_install().
+ */
+function localgov_media_install() {
+  // Add permission to use the WYSIWYG text format.
+  $role_object = Role::load('authenticated');
+  $role_object->grantPermission('use text format wysiwyg');
+  $role_object->save();
+}


### PR DESCRIPTION
This largely follows what's done on the Croydon site. I have tweaked it a bit. We will want to confirm exactly what buttons the CKEditor should contain and write some tests, but I suggest we do that as a separate issue and get this deployed as Will likely want to use it when adding example content.

Closes  #12.