### PR TITLE
Added home page welcome block

### DIFF
--- a/src/Plugin/Block/HomeWelcomeBlock.php
+++ b/src/Plugin/Block/HomeWelcomeBlock.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\localgov_core\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a 'Powered by LocalGovDrupal' block.
+ *
+ * @Block(
+ *   id = "localgov_home_welcome_block",
+ *   admin_label = @Translation("Home welcome block")
+ * )
+ */
+class HomeWelcomeBlock extends BlockBase implements BlockPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['label_display' => FALSE];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+
+    $config = $this->getConfiguration();
+
+    if (!empty($config['localgov_home_welcome_message'])) {
+      $message = $config['localgov_home_welcome_message'];
+    }
+    else {
+      $message = $this->t('<h2>You have just installed a LocalGov Drupal site</h2>');
+    }
+
+    return [
+      '#markup' => $message['value'],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+
+    $form = parent::blockForm($form, $form_state);
+    $config = $this->getConfiguration();
+
+    $form['localgov_home_welcome_message'] = [
+      '#type' => 'text_format',
+      '#format' => 'wysiwyg',
+      '#title' => $this->t('Welcome message'),
+      '#description' => $this->t('Site installation welcome message'),
+      '#default_value' => isset($config['localgov_home_welcome_message']) ? $config['localgov_home_welcome_message']['value'] : '',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+
+    $this->configuration['localgov_home_welcome_message'] = $form_state->getValue('localgov_home_welcome_message');
+  }
+
+}


### PR DESCRIPTION
This PR adds a block for a home page message to be displayed on installation of LocalGov Drupal. Provides default content.

Used by install profile as part of simple home page, see [/localgovdrupal/localgov/issues/96](/localgovdrupal/localgov/issues/96)