### PR TITLE
Media view modes for the Homepage Paragraphs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
     "require": {
         "drupal/field_group": "^3.1",
         "drupal/image_widget_crop": "^2.3",
-        "drupal/linkit": "^6.0-beta1"
+        "drupal/linkit": "^6.0-beta1",
+        "drupal/pathauto": "^1.8",
+        "drupal/token": "^1.7"
     },
     "extra": {
         "enable-patching": true,

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_featured.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_featured.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.localgov_featured
+    - field.field.media.image.field_media_image
+    - image.style.localgov_248x181
+    - media.type.image
+  module:
+    - image
+id: media.image.localgov_featured
+targetEntityType: media
+bundle: image
+mode: localgov_featured
+content:
+  field_media_image:
+    label: visually_hidden
+    settings:
+      image_style: localgov_248x181
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_featured_large.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_featured_large.yml
@@ -27,4 +27,3 @@ hidden:
   name: true
   thumbnail: true
   uid: true
-

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_featured_large.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_featured_large.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.localgov_featured_large
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.localgov_newsroom_featured
+  module:
+    - responsive_image
+id: media.image.localgov_featured_large
+targetEntityType: media
+bundle: image
+mode: localgov_featured_large
+content:
+  field_media_image:
+    label: visually_hidden
+    settings:
+      responsive_image_style: localgov_newsroom_featured
+      image_link: ''
+    third_party_settings: {  }
+    type: responsive_image
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true
+

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_newsroom_teaser.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_newsroom_teaser.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.localgov_newsroom_teaser
+    - field.field.media.image.field_media_image
+    - image.style.localgov_newsroom_teaser
+    - media.type.image
+  module:
+    - image
+id: media.image.localgov_newsroom_teaser
+targetEntityType: media
+bundle: image
+mode: localgov_newsroom_teaser
+content:
+  field_media_image:
+    label: visually_hidden
+    settings:
+      image_style: localgov_newsroom_teaser
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/localgov_media/config/optional/core.entity_view_mode.media.localgov_featured.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_mode.media.localgov_featured.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.localgov_featured
+label: Featured
+targetEntityType: media
+cache: true

--- a/modules/localgov_media/config/optional/core.entity_view_mode.media.localgov_featured_large.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_mode.media.localgov_featured_large.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.localgov_featured_large
+label: 'Featured large'
+targetEntityType: media
+cache: true

--- a/modules/localgov_media/config/optional/core.entity_view_mode.media.localgov_newsroom_teaser.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_mode.media.localgov_newsroom_teaser.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.localgov_newsroom_teaser
+label: 'Newsroom teaser'
+targetEntityType: media
+cache: true

--- a/modules/localgov_media/config/optional/crop.type.localgov_news_16_9.yml
+++ b/modules/localgov_media/config/optional/crop.type.localgov_news_16_9.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+id: 'localgov_news_16_9'
+label: '16:9 for News image'
+description: ''
+aspect_ratio: '16:9'
+soft_limit_width: null
+soft_limit_height: null
+hard_limit_width: null
+hard_limit_height: null

--- a/modules/localgov_media/config/optional/image.style.localgov_248x181.yml
+++ b/modules/localgov_media/config/optional/image.style.localgov_248x181.yml
@@ -1,0 +1,14 @@
+langcode: en
+status: true
+dependencies: {  }
+name: localgov_248x181
+label: LocalGov 248x181
+effects:
+  b8c93f24-2915-4be5-82fd-69940c874fe6:
+    uuid: b8c93f24-2915-4be5-82fd-69940c874fe6
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 248
+      height: 181
+      anchor: center-center

--- a/modules/localgov_media/config/optional/image.style.localgov_535x302.yml
+++ b/modules/localgov_media/config/optional/image.style.localgov_535x302.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.localgov_news_16_9
+  module:
+    - crop
+name: localgov_535x302
+label: LocalGov 535x302
+effects:
+  38cd1939-7fb0-43e0-86b1-604655d7e061:
+    uuid: 38cd1939-7fb0-43e0-86b1-604655d7e061
+    id: image_scale_and_crop
+    weight: -9
+    data:
+      width: 535
+      height: 302
+      anchor: center-center
+  ddbdb069-c2e0-4965-b6cc-7f1f2a3bb1d9:
+    uuid: ddbdb069-c2e0-4965-b6cc-7f1f2a3bb1d9
+    id: crop_crop
+    weight: -10
+    data:
+      crop_type: 'localgov_news_16_9'

--- a/modules/localgov_media/config/optional/image.style.localgov_newsroom_teaser.yml
+++ b/modules/localgov_media/config/optional/image.style.localgov_newsroom_teaser.yml
@@ -1,0 +1,14 @@
+langcode: en
+status: true
+dependencies: {  }
+name: localgov_newsroom_teaser
+label: 'LocalGov Newsroom teaser'
+effects:
+  ff65eadb-38a8-471d-ba15-f3e627e8afe1:
+    uuid: ff65eadb-38a8-471d-ba15-f3e627e8afe1
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 360
+      height: 200
+      anchor: center-center

--- a/modules/localgov_media/config/optional/responsive_image.styles.localgov_newsroom_featured.yml
+++ b/modules/localgov_media/config/optional/responsive_image.styles.localgov_newsroom_featured.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.localgov_248x181
+    - image.style.localgov_535x302
+  module:
+    - localgov_media
+id: localgov_newsroom_featured
+label: 'LocalGov Newsroom featured'
+image_style_mappings:
+  -
+    breakpoint_id: localgov_media.bootstrap4_md_768px
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: localgov_535x302
+breakpoint_group: localgov_media
+fallback_image_style: localgov_248x181

--- a/tests/localgov_core_page_header_event_test/localgov_core_page_header_event_test.info.yml
+++ b/tests/localgov_core_page_header_event_test/localgov_core_page_header_event_test.info.yml
@@ -1,4 +1,4 @@
 name: 'Page header display event test'
 type: module
 package: Testing
-core: 8.x
+core_version_requirement: ^8.8 || ^9


### PR DESCRIPTION
Hi Steve,
I have added three Entity view modes for the Media image: Newsroom teaser, Featured, Featured large.  The News image linked from the Newsroom teaser Paragraph can be displayed using these new view modes.

Task: https://github.com/localgovdrupal/localgov/issues/107