### PR TITLE
Fix fatal error with titleResolver

### DIFF
--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -156,8 +156,10 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   protected function getTitle() {
     $request = $this->requestStack->getCurrentRequest();
     $route = $this->currentRouteMatch->getRouteObject();
-
-    return $this->titleResolver->getTitle($request, $route);
+    if ($route) {
+      return $this->titleResolver->getTitle($request, $route);
+    }
+    return NULL;
   }
 
   /**


### PR DESCRIPTION
For some reason when cache rebuilding the getTitle function was getting called and throwing a fatal error. This wraps the return in a check, otherwise returns NULL.

The fatal error:

```
PHP Fatal error:  Uncaught TypeError: Argument 2 passed to Drupal\Core\Controller\TitleResolver::getTitle() must be an instance of Symfony\Component\Routing\Route, null given, called in /app/web/modules/contrib/localgov_core/src/Plugin/Block/PageHeaderBlock.php on line 160 and defined in /app/web/core/lib/Drupal/Core/Controller/TitleResolver.php:50
```

No idea why the block was being called on cache rebuild as it wasn't placed in my theme. Note that I haven't tested this solution other than to get past the fatal error, so I don't know if the block correctly returns values etc.