### PR TITLE
remove hardcoded classes from page title template that are not relevant to all themes

### DIFF
--- a/templates/localgov-page-header-block.html.twig
+++ b/templates/localgov-page-header-block.html.twig
@@ -8,16 +8,18 @@
 * @ingroup themeable
 */
 #}
-{% set classes = [
-    'clear-both',
-    'headers',
-    'key',
-] %}
+
+{% 
+  set classes = [
+    'page-title',
+  ] 
+%}
+
 {% if title %}
-<div{{ attributes.addClass(classes) }}>
-  <h1 class="header">{{ title }}</h1>
-  {% if lede %}
-  <div class="subheader">{{ lede }}</div>
-  {% endif %}
-</div>
+  <div{{ attributes.addClass(classes) }}>
+    <h1 class="page-title__title">{{ title }}</h1>
+    {% if lede %}
+      <div class="page-title__subtitle">{{ lede }}</div>
+    {% endif %}
+  </div>
 {% endif %}

--- a/templates/localgov-page-header-block.html.twig
+++ b/templates/localgov-page-header-block.html.twig
@@ -9,17 +9,22 @@
 */
 #}
 
-{% 
+{%
   set classes = [
-    'page-title',
-  ] 
+    'lgd-page-title-block'
+  ]
 %}
 
-{% if title %}
+{% if title or lede['#value'] %}
   <div{{ attributes.addClass(classes) }}>
-    <h1 class="page-title__title">{{ title }}</h1>
-    {% if lede %}
-      <div class="page-title__subtitle">{{ lede }}</div>
+
+    {% if title %}
+      <h1 class="lgd-page-title-block__title">{{ title }}</h1>
     {% endif %}
+
+    {% if lede['#value'] %}
+      <p class="lgd-page-title-block__subheader">{{ lede['#value'] }}</p>
+    {% endif %}
+
   </div>
 {% endif %}


### PR DESCRIPTION
This PR
1. Removes hard-coded classes from the `classes` array. These classes pre-suppose a specific CSS structure (I'm guessing Bootstrap), such as "clear-both".
2. Removes hard-coded `.header` class from the page title. This class should only be used for the main page header, so we can style that via a class instead of an element. Currently, having this class in this template is causing all my page titles to inherit the same CSS that my site header has!
3. Adds in generic classes that can be used by any theme, using BEM naming standards, based on a BEM block called `page-title` (I hope this doesn't conflict with the `.page-title` class in the core `page-title.html.twig` file, but I am guessing this template overrides that one.

I think it would probably be better to clone and manipulate the `page-title.html.twig` template rather than this very specific replacement. But we can discuss that on the technical group chats. 