### PR TITLE
Corrected label and link of 'Powered by LocalGov Drupal' block.

### DIFF
--- a/src/Plugin/Block/PoweredByLocalGovDrupal.php
+++ b/src/Plugin/Block/PoweredByLocalGovDrupal.php
@@ -9,7 +9,7 @@ use Drupal\Core\Block\BlockBase;
  *
  * @Block(
  *   id = "localgov_powered_by_block",
- *   admin_label = @Translation("Powered by LocalGovDrupal")
+ *   admin_label = @Translation("Powered by LocalGov Drupal")
  * )
  */
 class PoweredByLocalGovDrupal extends BlockBase {
@@ -25,7 +25,7 @@ class PoweredByLocalGovDrupal extends BlockBase {
    * {@inheritdoc}
    */
   public function build() {
-    return ['#markup' => '<span>' . $this->t('Powered by <a href=":poweredby">LocalGovDrupal</a>', [':poweredby' => 'https://github.com/localgovdrupal/localgov']) . '</span>'];
+    return ['#markup' => '<span>' . $this->t('Powered by <a href=":poweredby">LocalGov Drupal</a>', [':poweredby' => 'https://localgovdrupal.org/']) . '</span>'];
   }
 
 }


### PR DESCRIPTION
When doing a site install of the LocalGov profile a 'Powered by LocalGov Drupal' block is placed in the footer. This pull request fixes the spacing in the label and updates the link the block points to.

Closes #62 