### PR TITLE
*drush deploy* compatible field renaming

### DIFF
--- a/src/FieldRenameHelper.php
+++ b/src/FieldRenameHelper.php
@@ -51,6 +51,12 @@ class FieldRenameHelper {
     unset($new_field_storage['_core']);
     $new_field_storage['field_name'] = $new_field_name;
     $new_field_storage['id'] = str_replace($old_field_name, $new_field_name, $new_field_storage['id']);
+    // Useful where config file for this new field storage has been already
+    // exported after database update in a *development* site.
+    if ($existing_field_storage_config = \Drupal::service('config.storage.sync')->read("field.storage.{$new_field_storage['id']}")) {
+      $new_field_storage['uuid'] = $existing_field_storage_config['uuid'] ?? '';
+    }
+
     $new_field_storage = FieldStorageConfig::create($new_field_storage);
     $new_field_storage->original = $new_field_storage;
     $new_field_storage->enforceIsNew(TRUE);
@@ -78,6 +84,11 @@ class FieldRenameHelper {
         $new_field['field_name'] = $new_field_name;
         $new_field['id'] = str_replace($old_field_name, $new_field_name, $new_field['id']);
         $new_field['dependencies']['config'][0] = str_replace($old_field_name, $new_field_name, $new_field['dependencies']['config'][0]);
+        // In case this new field's config file already exists.
+        if ($existing_field_config = \Drupal::service('config.storage.sync')->read("field.field.{$new_field['id']}")) {
+          $new_field['uuid'] = $existing_field_config['uuid'] ?? '';
+        }
+
         $new_field = FieldConfig::create($new_field);
         $new_field->original = $dependent;
         $new_field->enforceIsNew(TRUE);


### PR DESCRIPTION
At the moment, field renaming involves exporting configuration files in the *live* site after running the relevant database updates.  This is different from the usual deployment process where database updates are run in a development machine, configs are exported and then *drush deploy* or equivalent is used by a CI/CD system to deploy Drupal in the live site.

The current process is necessary because every time the database updates for field renaming are run, they generate **different UUID** values for field configs which instantly makes the new field config out-of-sync with any config file on the disk.  To avoid this, we should source the UUIDs from config files on the disk *when* such files are present.  This makes the process *drush deploy* compatible.

### How to test
- drush --yes updb
- drush --yes config:export
- drush --yes sql:drop; drush sql:query --file=/path/to/database/dump.sql
- drush deploy

This, as expected, would wipe out any data from all the new fields (e.g. localgov_twitter, localgov_page_components, etc.) **unless** this minor change has been applied.  This change avoids the data loose scenario as it sources the UUIDs from config files on the disk wherever possible.