### PR TITLE
1.0.1 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,11 @@ name: Test LocalGov Drupal Core
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - '1.x'
   pull_request:
-    branches: [ master ]
+    branches:
+      - '1.x'
 
 jobs:
 
@@ -12,52 +14,81 @@ jobs:
     name: Install LocalGov Drupal
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
+
     steps:
+    
+      - name: Save git branch and git repo names to env if this is not a pull request
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "GIT_BASE=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+          
+      - name: Save git branch and git repo names to env if this is a pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "GIT_BASE=${GITHUB_BASE_REF}" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+  
+      - name: Set composer branch reference for version branches
+        if: endsWith(github.ref, '.x')
+        run: echo "COMPOSER_REF=${GIT_BRANCH}-dev" >> $GITHUB_ENV
+          
+      - name: Set composer branch reference for non-version branches
+        if: endsWith(github.ref, '.x') == false
+        run: echo "COMPOSER_REF=dev-${GIT_BRANCH}" >> $GITHUB_ENV
 
       - name: Cached workspace
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-version }}
 
       - name: Clone drupal_container
         uses: actions/checkout@v2
         with:
           repository: localgovdrupal/drupal-container
-          ref: master
+          ref: php${{ matrix.php-version }}
 
       - name: Create LocalGov Drupal project
-        run: composer create-project --stability dev localgovdrupal/localgov-project ./html
-
-      - name: Save git branch and git repo names to env if this is not a pull request
-        if: github.event_name != 'pull_request'
         run: |
-          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
-
-      - name: Save git branch and git repo names to env if this is a pull request
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
-          echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
-
+          composer create-project --stability dev --no-install localgovdrupal/localgov-project ./html "${{ matrix.localgov-version }}"
+          composer require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
+          composer install
+          
       - name: Setup package source and authentication for the test target
         run: |
           composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
           composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Obtain the test target from the repo that triggered this workflow
-        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
+        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%'.x'}"
 
   phpcs:
     name: Coding standards checks
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
 
     steps:
 
@@ -65,10 +96,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-localgov-build-
-
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -78,11 +108,18 @@ jobs:
         run: |
           cd html
           ./bin/phpcs -p
-
   phpstan:
     name: Deprecated code checks
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
 
     steps:
 
@@ -90,10 +127,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-localgov-build-
-
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -103,11 +139,18 @@ jobs:
         run: |
           cd html
           ./bin/phpstan analyse -c ./phpstan.neon ./web/profiles/contrib/localgov/ ./web/modules/contrib/localgov_*
-
   phpunit:
     name: PHPUnit tests
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
 
     steps:
 
@@ -121,10 +164,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-localgov-build-
-
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
       - name: Start Docker environment
         run: docker-compose -f docker-compose.yml up -d
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         "drupal/redirect": "^1.6",
         "drupal/token": "^1.7"
     },
+    "require-dev": {
+        "drupal/paragraphs": "^1.12"
+    },
     "extra": {
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,

--- a/localgov_core.info.yml
+++ b/localgov_core.info.yml
@@ -9,3 +9,6 @@ dependencies:
   - drupal:field
   - drupal:node
   - field_group:field_group
+
+test_dependencies:
+  - paragraphs:paragraphs

--- a/src/FieldRenameHelper.php
+++ b/src/FieldRenameHelper.php
@@ -72,6 +72,7 @@ class FieldRenameHelper {
     }
 
     // Update paragraphs.
+    // @todo Fix for all entity reference revision types.
     $field_settings = $field_storage->get('settings');
     if (!empty($field_settings['target_type']) && $field_settings['target_type'] == 'paragraph') {
       self::fixParagraphTables($entity_type, $old_field_name, $new_field_name);

--- a/src/FieldRenameHelper.php
+++ b/src/FieldRenameHelper.php
@@ -172,14 +172,15 @@ class FieldRenameHelper {
   }
 
   /**
-   * Fix the paragraph table with the renamed fields
+   * Fix the paragraph table with the renamed fields.
    *
    * See https://github.com/localgovdrupal/localgov_core/issues/75
-   * @param  string $host_entity_type_id
+   *
+   * @param string $host_entity_type_id
    *   Entity type eg. Node.
-   * @param  string $src_field
+   * @param string $src_field
    *   Source field name.
-   * @param  string $cloned_field
+   * @param string $cloned_field
    *   New field name.
    */
   public static function fixParagraphTables(string $host_entity_type_id, string $src_field, string $cloned_field): void {
@@ -188,13 +189,13 @@ class FieldRenameHelper {
     $logger = \Drupal::service('logger.factory')->get('localgov_core');
 
     $paragraph_tables = ['paragraphs_item_field_data', 'paragraphs_item_revision_field_data'];
-    foreach($paragraph_tables as $paragraph_data_table) {
+    foreach ($paragraph_tables as $paragraph_data_table) {
       try {
         $db->update($paragraph_data_table)
-           ->fields(['parent_field_name' => $cloned_field])
-           ->condition('parent_type', $host_entity_type_id)
-           ->condition('parent_field_name', $src_field)
-           ->execute();
+          ->fields(['parent_field_name' => $cloned_field])
+          ->condition('parent_type', $host_entity_type_id)
+          ->condition('parent_field_name', $src_field)
+          ->execute();
       }
       catch (\Exception $e) {
         $logger->warning('Failed to update %paragraph_data_table table parent_field_name column for %src_field to %cloned_field on %host_entity_type_id.  More: %msg', [

--- a/src/FieldRenameHelper.php
+++ b/src/FieldRenameHelper.php
@@ -73,9 +73,12 @@ class FieldRenameHelper {
 
     // Update paragraphs.
     // @todo Fix for all entity reference revision types.
+    $field_type = $field_storage->get('type');
     $field_settings = $field_storage->get('settings');
-    if (!empty($field_settings['target_type']) && $field_settings['target_type'] == 'paragraph') {
-      self::fixParagraphTables($entity_type, $old_field_name, $new_field_name);
+    if ($field_type == 'entity_reference_revisions') {
+      if ($field_settings['target_type'] == 'paragraph') {
+        self::fixParagraphTables($entity_type, $old_field_name, $new_field_name);
+      }
     }
 
     // Update the field config on each bundle.

--- a/tests/src/Kernel/FieldRenameHelperTest.php
+++ b/tests/src/Kernel/FieldRenameHelperTest.php
@@ -275,8 +275,8 @@ class FieldRenameHelperTest extends KernelTestBase {
     $this->assertEquals(TRUE, $result_paragraph->hasField('field_text'));
     $this->assertEquals($paragraph_text, $result_paragraph->field_text->value);
 
-    // Run the cron (un the workers that do paragraph garbage collection).
-    \Drupal::service('cron')->run();
+    // Run the entity reference revisions purger for paragraphs.
+    _entity_reference_revisions_orphan_purger_batch_dispatcher('entity_reference_revisions.orphan_purger:deleteOrphansBatchOperation', 'paragraph', []);
 
     // Reload the node for the post cron tests.
     $result_node_post_cron = Node::load($nid);


### PR DESCRIPTION
Fix for the paragraph field rename.

Commits on May 19, 2021
@stephen-cox
Updated Github CI to run 1.x branch against Drupal 8 (#71)
b7afc5f
Commits on May 20, 2021
@andybroomfield
Update paragraph tables with references to new field names …
d7d0176
@andybroomfield
Coding standards fixes
e43fab3
Commits on May 21, 2021
@andybroomfield
Add test for paragraph fix on field rename …
201b9dc
Commits on May 22, 2021
@andybroomfield
Coding standards fix and rename the test
72517db
Commits on May 23, 2021
@andybroomfield
Fix test to call the entity reference revisions purger …
2afb3f1
Commits on May 24, 2021
@andybroomfield
Add extra if to fieldrenamehelper to detect entity_referenece_revisions …
88b4cb2
Commits on May 25, 2021
@andybroomfield
Throw exception if renaming a non paragraph entity_reference_revisions
3f2ba37
Commits on May 26, 2021
@andybroomfield
Merge pull request #76 from localgovdrupal/fix/75-fix-paragraphs …
defa403