### PR TITLE
2.0.1 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
           composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Obtain the test target from the repo that triggered this workflow
-        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%}-dev"
+        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%'.x'}"
 
   phpcs:
     name: Coding standards checks

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         "drupal/redirect": "^1.6",
         "drupal/token": "^1.7"
     },
+    "require-dev": {
+        "drupal/paragraphs": "^1.12"
+    },
     "extra": {
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,

--- a/localgov_core.info.yml
+++ b/localgov_core.info.yml
@@ -9,3 +9,6 @@ dependencies:
   - drupal:field
   - drupal:node
   - field_group:field_group
+
+test_dependencies:
+  - paragraphs:paragraphs

--- a/src/FieldRenameHelper.php
+++ b/src/FieldRenameHelper.php
@@ -197,7 +197,10 @@ class FieldRenameHelper {
     $db = \Drupal::database();
     $logger = \Drupal::service('logger.factory')->get('localgov_core');
 
-    $paragraph_tables = ['paragraphs_item_field_data', 'paragraphs_item_revision_field_data'];
+    $paragraph_tables = [
+      'paragraphs_item_field_data',
+      'paragraphs_item_revision_field_data'
+    ];
     foreach ($paragraph_tables as $paragraph_data_table) {
       try {
         $db->update($paragraph_data_table)

--- a/src/FieldRenameHelper.php
+++ b/src/FieldRenameHelper.php
@@ -72,6 +72,7 @@ class FieldRenameHelper {
     }
 
     // Update paragraphs.
+    // @todo Fix for all entity reference revision types.
     $field_settings = $field_storage->get('settings');
     if (!empty($field_settings['target_type']) && $field_settings['target_type'] == 'paragraph') {
       self::fixParagraphTables($entity_type, $old_field_name, $new_field_name);

--- a/src/FieldRenameHelper.php
+++ b/src/FieldRenameHelper.php
@@ -172,14 +172,15 @@ class FieldRenameHelper {
   }
 
   /**
-   * Fix the paragraph table with the renamed fields
+   * Fix the paragraph table with the renamed fields.
    *
    * See https://github.com/localgovdrupal/localgov_core/issues/75
-   * @param  string $host_entity_type_id
+   *
+   * @param string $host_entity_type_id
    *   Entity type eg. Node.
-   * @param  string $src_field
+   * @param string $src_field
    *   Source field name.
-   * @param  string $cloned_field
+   * @param string $cloned_field
    *   New field name.
    */
   public static function fixParagraphTables(string $host_entity_type_id, string $src_field, string $cloned_field): void {
@@ -188,13 +189,13 @@ class FieldRenameHelper {
     $logger = \Drupal::service('logger.factory')->get('localgov_core');
 
     $paragraph_tables = ['paragraphs_item_field_data', 'paragraphs_item_revision_field_data'];
-    foreach($paragraph_tables as $paragraph_data_table) {
+    foreach ($paragraph_tables as $paragraph_data_table) {
       try {
         $db->update($paragraph_data_table)
-           ->fields(['parent_field_name' => $cloned_field])
-           ->condition('parent_type', $host_entity_type_id)
-           ->condition('parent_field_name', $src_field)
-           ->execute();
+          ->fields(['parent_field_name' => $cloned_field])
+          ->condition('parent_type', $host_entity_type_id)
+          ->condition('parent_field_name', $src_field)
+          ->execute();
       }
       catch (\Exception $e) {
         $logger->warning('Failed to update %paragraph_data_table table parent_field_name column for %src_field to %cloned_field on %host_entity_type_id.  More: %msg', [

--- a/src/FieldRenameHelper.php
+++ b/src/FieldRenameHelper.php
@@ -199,7 +199,7 @@ class FieldRenameHelper {
 
     $paragraph_tables = [
       'paragraphs_item_field_data',
-      'paragraphs_item_revision_field_data'
+      'paragraphs_item_revision_field_data',
     ];
     foreach ($paragraph_tables as $paragraph_data_table) {
       try {

--- a/src/FieldRenameHelper.php
+++ b/src/FieldRenameHelper.php
@@ -73,9 +73,12 @@ class FieldRenameHelper {
 
     // Update paragraphs.
     // @todo Fix for all entity reference revision types.
+    $field_type = $field_storage->get('type');
     $field_settings = $field_storage->get('settings');
-    if (!empty($field_settings['target_type']) && $field_settings['target_type'] == 'paragraph') {
-      self::fixParagraphTables($entity_type, $old_field_name, $new_field_name);
+    if ($field_type == 'entity_reference_revisions') {
+      if ($field_settings['target_type'] == 'paragraph') {
+        self::fixParagraphTables($entity_type, $old_field_name, $new_field_name);
+      }
     }
 
     // Update the field config on each bundle.

--- a/tests/src/Kernel/FieldRenameHelperTest.php
+++ b/tests/src/Kernel/FieldRenameHelperTest.php
@@ -275,8 +275,8 @@ class FieldRenameHelperTest extends KernelTestBase {
     $this->assertEquals(TRUE, $result_paragraph->hasField('field_text'));
     $this->assertEquals($paragraph_text, $result_paragraph->field_text->value);
 
-    // Run the cron (un the workers that do paragraph garbage collection).
-    \Drupal::service('cron')->run();
+    // Run the entity reference revisions purger for paragraphs.
+    _entity_reference_revisions_orphan_purger_batch_dispatcher('entity_reference_revisions.orphan_purger:deleteOrphansBatchOperation', 'paragraph', []);
 
     // Reload the node for the post cron tests.
     $result_node_post_cron = Node::load($nid);


### PR DESCRIPTION
Includes the forward port of the paragraphs fix #81.

Commits on May 26, 2021
@stephen-cox
Fix GitHub CI after 2.0.0 release (#80)
Verified
17d3b25

@andybroomfield
Update paragraph tables with references to new field names  …
75d9420

@andybroomfield
Coding standards fixes
5eb35ac

@andybroomfield
Add test for paragraph fix on field rename  …
6445325

@andybroomfield
Coding standards fix and rename the test
278807d

@andybroomfield
Fix test to call the entity reference revisions purger  …
e4100e3

@andybroomfield
Add extra if to fieldrenamehelper to detect entity_referenece_revisions  …
95bac6f

@andybroomfield
Throw exception if renaming a non paragraph entity_reference_revisions
 ffdffaa

@andybroomfield
code standards fix
 b679a07

@finnlewis
Fix coding standards.
 6db6daa

Commits on May 27, 2021
@andybroomfield
Merge pull request #81 from localgovdrupal/fix/75-2.x-fix-paragraph  …
Verified
b4d7cf0