### PR TITLE
Include email matcher in default LinkIt profile

### DIFF
--- a/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
+++ b/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
@@ -18,3 +18,8 @@ matchers:
       include_unpublished: false
       substitution_type: canonical
       limit: 100
+  c3257417-fce9-4307-8251-58672edf88be:
+    uuid: c3257417-fce9-4307-8251-58672edf88be
+    id: email
+    weight: 0
+    settings: {  }


### PR DESCRIPTION
1.x backport, closes #85 

Enables email matcher in default LinkIt profile.