### PR TITLE
Release 2.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "drupal/ctools": "3.9",
         "drupal/field_group": "^3.1",
         "drupal/image_widget_crop": "^2.3",
         "drupal/linkit": "^6.0-beta1",

--- a/localgov_core.install
+++ b/localgov_core.install
@@ -30,3 +30,30 @@ function localgov_core_update_8001(&$sandbox) {
 
   return t('Please export your sites configuration! Config entities for localgov_core where updated.');
 }
+
+/**
+ * Update node type conditions from node_type to entity_bundle.
+ *
+ * @see pathauto_update_8108()
+ * This runs the same update for any sites that installed our default pathauto
+ * patters after the pathauto update was added.
+ */
+function localgov_core_update_8002() {
+  // Load all pattern configuration entities.
+  foreach (\Drupal::configFactory()->listAll('pathauto.pattern.') as $pattern_config_name) {
+    $pattern_config = \Drupal::configFactory()->getEditable($pattern_config_name);
+
+    // Loop patterns and swap the node_type plugin by the entity_bundle:node
+    // plugin.
+    if ($pattern_config->get('type') === 'canonical_entities:node') {
+      $selection_criteria = $pattern_config->get('selection_criteria');
+      foreach ($selection_criteria as $uuid => $condition) {
+        if ($condition['id'] === 'node_type') {
+          $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
+          $pattern_config->save();
+          break;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
All modules should have had their install configuration updated. The
update hook fixes any sites that had installed the configuration after
pathauto updated patterns. After both have been done then ctools can be
unpinned - it also becomes no longer a pathauto dependency.

Co-authored-by: Stephen Cox <stephen-cox@users.noreply.github.com>
Co-authored-by: Finn Lewis <finn@agile.coop>