### PR TITLE
Adds a mechanism for subscribers to PageHeaderDisplayEvent to set the cache tags on the PageHeaderBlock.

### DIFF
--- a/src/Event/PageHeaderDisplayEvent.php
+++ b/src/Event/PageHeaderDisplayEvent.php
@@ -40,6 +40,13 @@ class PageHeaderDisplayEvent extends Event {
   protected $visibility = TRUE;
 
   /**
+   * Cache tags override.
+   *
+   * @var array|null
+   */
+  protected $cacheTags = NULL;
+
+  /**
    * {@inheritdoc}
    */
   public function __construct($entity) {
@@ -114,6 +121,25 @@ class PageHeaderDisplayEvent extends Event {
    */
   public function setVisibility($visibility) {
     $this->visibility = $visibility;
+  }
+
+  /**
+   * Cache tags getter.
+   *
+   * @return array|null
+   */
+  public function getCacheTags() {
+    return $this->cacheTags;
+  }
+
+  /**
+   * Cache tags setter.
+   *
+   * @param array $cacheTags
+   *   The cache tags.
+   */
+  public function setCacheTags(array $cacheTags) {
+    $this->cacheTags = $cacheTags;
   }
 
 }

--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -84,6 +84,13 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   protected $visible;
 
   /**
+   * Cache tags for this block.
+   *
+   * @var array
+   */
+  protected $cacheTags;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
@@ -126,10 +133,12 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $event = new PageHeaderDisplayEvent($this->entity);
     $this->eventDispatcher->dispatch($event, PageHeaderDisplayEvent::EVENT_NAME);
 
-    // Set the title, lede and visibility.
+    // Set the title, lede, visibility and cache tags.
     $this->title = is_null($event->getTitle()) ? $this->getTitle() : $event->getTitle();
     $this->lede = is_null($event->getLede()) ? $this->getLede() : $event->getLede();
     $this->visible = $event->getVisibility();
+    $entityCacheTags = is_null($this->entity) ? [] : $this->entity->getCacheTags();
+    $this->cacheTags = is_null($event->getCacheTags()) ? $entityCacheTags : $event->getCacheTags();
   }
 
   /**
@@ -214,8 +223,8 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
    * {@inheritdoc}
    */
   public function getCacheTags() {
-    if (!is_null($this->entity)) {
-      return Cache::mergeTags(parent::getCacheTags(), $this->entity->getCacheTags());
+    if (!empty($this->cacheTags)) {
+      return Cache::mergeTags(parent::getCacheTags(), $this->cacheTags);
     }
     return parent::getCacheTags();
   }

--- a/tests/localgov_core_page_header_event_test/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/tests/localgov_core_page_header_event_test/src/EventSubscriber/PageHeaderSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\localgov_core_page_header_event_test\EventSubscriber;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\node\Entity\Node;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\localgov_core\Event\PageHeaderDisplayEvent;
@@ -27,19 +28,28 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
    */
   public function setPageHeader(PageHeaderDisplayEvent $event) {
 
+    $node = $event->getEntity();
+
+    if (!$node instanceof Node) {
+      return;
+    }
+
     // Override title and lede for page1 node content types.
-    if ($event->getEntity() instanceof Node &&
-      $event->getEntity()->bundle() == 'page1'
-    ) {
+    if ($node->bundle() == 'page1') {
       $event->setTitle('Overridden title');
       $event->setLede('Overridden lede');
     }
 
     // Hide page header block for page2 content types.
-    if ($event->getEntity() instanceof Node &&
-      $event->getEntity()->bundle() == 'page2'
-    ) {
+    if ($node->bundle() == 'page2') {
       $event->setVisibility(FALSE);
+    }
+
+    // Set lede from summary, and cache tags from the parent for page3 nodes.
+    if ($node->bundle() == 'page3') {
+      $parent = $node->parent->entity;
+      $event->setLede($parent->body->summary);
+      $event->setCacheTags(Cache::mergeTags($node->getCacheTags(), $parent->getCacheTags()));
     }
   }
 

--- a/tests/src/Functional/PageHeaderBlockTest.php
+++ b/tests/src/Functional/PageHeaderBlockTest.php
@@ -2,11 +2,14 @@
 
 namespace Drupal\Tests\localgov_core\Functional;
 
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\taxonomy\Traits\TaxonomyTestTrait;
+
 
 /**
  * Functional tests for LocalGovDrupal install profile.
@@ -119,6 +122,67 @@ class PageHeaderBlockTest extends BrowserTestBase {
     $this->assertSession()->pageTextNotContains($summary);
     $this->assertSession()->responseNotContains('<h1 class="header">Overridden title</h1>');
     $this->assertSession()->pageTextNotContains('Overridden lede');
+
+    // Check cache tags override.
+    // Set up a page3 that can reference other page3 nodes.
+    $this->createContentType(['type' => 'page3']);
+
+    FieldStorageConfig::create([
+      'field_name' => 'parent',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'cardinality' => -1,
+      'settings' => [
+        'target_type' => 'node',
+      ],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'parent',
+      'entity_type' => 'node',
+      'bundle' => 'page3',
+      'label' => 'Parent',
+      'cardinality' => -1,
+    ])->save();
+
+    $page3parent = $this->createNode([
+      'type' => 'page3',
+      'title' => 'page 3 parent title',
+      'body' => [
+        'summary' => 'page 3 parent summary',
+        'value' => '',
+      ],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $page3child = $this->createNode([
+      'type' => 'page3',
+      'title' => 'page 3 child title',
+      'body' => [
+        'summary' => 'page 3 child summary',
+        'value' => '',
+      ],
+      'parent' => [
+        'target_id' => $page3parent->id(),
+      ],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    // Load the child page.
+    $this->drupalGet($page3child->toUrl()->toString());
+
+    // Check the child page contains the parent summary.
+    $this->assertSession()->pageTextContains('page 3 parent summary');
+
+    // Update the parent summary.
+    $page3parent->body->summary = 'page 3 parent updated summary';
+    $page3parent->save();
+
+    // Reload the child page.
+    $this->drupalGet($page3child->toUrl()->toString());
+
+    // Check the child page contains the updated parent summary.
+    $this->assertSession()->pageTextContains('page 3 parent updated summary');
   }
 
 }


### PR DESCRIPTION
This is to fix an issue on guide pages. On guide pages \Drupal\localgov_guides\EventSubscriber\PageHeaderSubscriber displays the title and summary of the guide parent page in the PageHeaderBlock, but has no way to update the cache tags on the block to allow the block to update when the parent page is changed.

This PR adds a mechanism for listeners to PageHeaderDisplayEvent to override the block's cache tags if they include data from other entities.