### PR TITLE
Adds a separate check for node_preview to entity definition code

### DIFF
--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -117,14 +117,28 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $this->titleResolver = $title_resolver;
 
     // Find the entity, if any, associated with the current route.
+    //
+    // We consider two cases: (1) type entity:*, and (2) type node_preview with
+    // view_mode_id set to 'full'.
     if (($route = $this->currentRouteMatch->getRouteObject()) && ($parameters = $route->getOption('parameters'))) {
       foreach ($parameters as $name => $options) {
-        if (isset($options['type']) && strpos($options['type'], 'entity:') === 0) {
+        if (!isset($options['type'])) {
+          continue;
+        }
+
+        if (strpos($options['type'], 'entity:') === 0) {
           $entity = $this->currentRouteMatch->getParameter($name);
-          if ($entity instanceof EntityInterface) {
-            $this->entity = $entity;
-            break;
+        }
+        else if ($options['type'] === 'node_preview') {
+          $preview = $this->currentRouteMatch->getParentRouteMatch()->getParameter($name);
+          if (isset($preview->preview_view_mode) && $preview->preview_view_mode === 'full') {
+            $entity = $preview;
           }
+        }
+
+        if (isset($entity) && $entity instanceof EntityInterface) {
+          $this->entity = $entity;
+          break;
         }
       }
     }


### PR DESCRIPTION
- Slightly restructures the loop to avoid nesting conditionals and to enable the structure to accommodate other nonstandard cases if any should come up.
- The flow for each iteration is now:
    - exit iteration if $options['type'] is not set;
    - set $entity if $options['type'] is 'entity:*';
    - alternately, set $entity if $options['type'] is 'node_preview' AND its view mode is set to 'full'; 
    - set $this->entity to $entity if a) it's set, and b) it's an instance of EntityInterface;
- Re: 168_pageheaderblock_php_does_not_render_lede_in_node_preview

(Manually) tested for the following conditions on multiple LGD content types:

- node does not exist, preview lede displays correctly
- node already exists, preview lede displays correctly