### PR TITLE
fix: add missing image_loading attribute to config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Test localgovdrupal/localgov_core drupal-module
 on:
   push:
     branches:
-      - '3.x'
+      - '2.x'
   pull_request:
     branches:
-      - '3.x'
+      - '2.x'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - localgov-version: '2.x'
-            drupal-version: '~9.4'
+            drupal-version: '~9.5'
             php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
@@ -107,7 +107,7 @@ jobs:
       matrix:
         include:
           - localgov-version: '2.x'
-            drupal-version: '~9.4'
+            drupal-version: '~9.5'
             php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
@@ -143,7 +143,7 @@ jobs:
       matrix:
         include:
           - localgov-version: '2.x'
-            drupal-version: '~9.4'
+            drupal-version: '~9.5'
             php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
@@ -178,7 +178,7 @@ jobs:
       matrix:
         include:
           - localgov-version: '2.x'
-            drupal-version: '~9.4'
+            drupal-version: '~9.5'
             php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: 
-              - '8.1'
-              - '8.2'
+        localgov-version: 
+          - '3.x'
+        drupal-version:
+          - '~10.1'
+        php-version: 
+          - '8.1'
+          - '8.2'
 
     steps:
 
@@ -104,12 +105,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: 
-              - '8.1'
-              - '8.2'
+        localgov-version: 
+          - '3.x'
+        drupal-version:
+          - '~10.1'
+        php-version: 
+          - '8.1'
+          - '8.2'
 
     steps:
 
@@ -139,12 +141,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: 
-              - '8.1'
-              - '8.2'
+        localgov-version: 
+          - '3.x'
+        drupal-version:
+          - '~10.1'
+        php-version: 
+          - '8.1'
+          - '8.2'
 
     steps:
 
@@ -173,12 +176,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: 
-              - '8.1'
-              - '8.2'
+        localgov-version: 
+          - '3.x'
+        drupal-version:
+          - '~10.1'
+        php-version: 
+          - '8.1'
+          - '8.2'
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Test localgovdrupal/localgov_core drupal-module
 on:
   push:
     branches:
-      - '2.x'
+      - '3.x'
   pull_request:
     branches:
-      - '2.x'
+      - '3.x'
 
 env:
   LOCALGOV_DRUPAL_PROJECT: localgovdrupal/localgov_core
@@ -22,12 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.5'
-            php-version: '8.1'
           - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+            drupal-version: '~10.1'
+            php-version:
+              - '8.1'
+              - '8.2'
 
     steps:
 
@@ -106,12 +105,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.5'
-            php-version: '8.1'
           - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+            drupal-version: '~10.1'
+            php-version:
+              - '8.1'
+              - '8.2'
 
     steps:
 
@@ -142,12 +140,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.5'
-            php-version: '8.1'
           - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+            drupal-version: '~10.1'
+            php-version:
+              - '8.1'
+              - '8.2'
 
     steps:
 
@@ -177,12 +174,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.5'
-            php-version: '8.1'
           - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+            drupal-version: '~10.1'
+            php-version:
+              - '8.1'
+              - '8.2'
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '3.x'
+  workflow_dispatch:
 
 env:
   LOCALGOV_DRUPAL_PROJECT: localgovdrupal/localgov_core
@@ -21,11 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version: 
+        localgov-version:
           - '3.x'
         drupal-version:
           - '~10.1'
-        php-version: 
+        php-version:
           - '8.1'
           - '8.2'
 
@@ -105,11 +106,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version: 
+        localgov-version:
           - '3.x'
         drupal-version:
           - '~10.1'
-        php-version: 
+        php-version:
           - '8.1'
           - '8.2'
 
@@ -141,11 +142,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version: 
+        localgov-version:
           - '3.x'
         drupal-version:
           - '~10.1'
-        php-version: 
+        php-version:
           - '8.1'
           - '8.2'
 
@@ -176,11 +177,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version: 
+        localgov-version:
           - '3.x'
         drupal-version:
           - '~10.1'
-        php-version: 
+        php-version:
           - '8.1'
           - '8.2'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          localgov-version: '3.x'
-          drupal-version: '~10.1'
-          php-version:
-            - '8.1'
-            - '8.2'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: 
+              - '8.1'
+              - '8.2'
 
     steps:
 
@@ -105,11 +105,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          localgov-version: '3.x'
-          drupal-version: '~10.1'
-          php-version:
-            - '8.1'
-            - '8.2'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: 
+              - '8.1'
+              - '8.2'
 
     steps:
 
@@ -140,11 +140,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          localgov-version: '3.x'
-          drupal-version: '~10.1'
-          php-version:
-            - '8.1'
-            - '8.2'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: 
+              - '8.1'
+              - '8.2'
 
     steps:
 
@@ -174,11 +174,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          localgov-version: '3.x'
-          drupal-version: '~10.1'
-          php-version:
-            - '8.1'
-            - '8.2'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: 
+              - '8.1'
+              - '8.2'
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.1'
-            php-version:
-              - '8.1'
-              - '8.2'
+          localgov-version: '3.x'
+          drupal-version: '~10.1'
+          php-version:
+            - '8.1'
+            - '8.2'
 
     steps:
 
@@ -105,11 +105,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.1'
-            php-version:
-              - '8.1'
-              - '8.2'
+          localgov-version: '3.x'
+          drupal-version: '~10.1'
+          php-version:
+            - '8.1'
+            - '8.2'
 
     steps:
 
@@ -140,11 +140,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.1'
-            php-version:
-              - '8.1'
-              - '8.2'
+          localgov-version: '3.x'
+          drupal-version: '~10.1'
+          php-version:
+            - '8.1'
+            - '8.2'
 
     steps:
 
@@ -174,11 +174,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.1'
-            php-version:
-              - '8.1'
-              - '8.2'
+          localgov-version: '3.x'
+          drupal-version: '~10.1'
+          php-version:
+            - '8.1'
+            - '8.2'
 
     steps:
 

--- a/localgov_core.info.yml
+++ b/localgov_core.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Core
 description: LocalGov Drupal helper functions and core dependencies.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10.1
 
 dependencies:
   - drupal:block

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.default.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.default.yml
@@ -18,6 +18,8 @@ content:
     settings:
       responsive_image_style: 3_2_image
       image_link: ''
+      image_loading:
+        attribute: lazy
     third_party_settings: {}
     weight: 1
     region: content

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.freestyle.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.freestyle.yml
@@ -19,6 +19,8 @@ content:
     settings:
       responsive_image_style: freestyle_responsive
       image_link: ''
+      image_loading:
+        attribute: lazy
     third_party_settings: {  }
     weight: 1
     region: content

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_featured_large.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.localgov_featured_large.yml
@@ -19,6 +19,8 @@ content:
     settings:
       responsive_image_style: localgov_newsroom_featured
       image_link: ''
+      image_loading:
+        attribute: lazy
     third_party_settings: {}
     weight: 1
     region: content

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.responsive_3x2.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.responsive_3x2.yml
@@ -19,6 +19,8 @@ content:
     settings:
       responsive_image_style: 3_2_image
       image_link: ''
+      image_loading:
+        attribute: lazy
     third_party_settings: {}
     weight: 1
     region: content

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.responsive_banner.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.responsive_banner.yml
@@ -19,6 +19,8 @@ content:
     settings:
       responsive_image_style: banner_28_9
       image_link: ''
+      image_loading:
+        attribute: lazy
     third_party_settings: {}
     weight: 1
     region: content

--- a/modules/localgov_media/config/optional/core.entity_view_display.media.image.square.yml
+++ b/modules/localgov_media/config/optional/core.entity_view_display.media.image.square.yml
@@ -19,6 +19,8 @@ content:
     settings:
       responsive_image_style: square
       image_link: ''
+      image_loading:
+        attribute: lazy
     third_party_settings: {}
     weight: 1
     region: content


### PR DESCRIPTION
This fixes the following deprecation error;

```
The responsive image loading attribute update for "X" is deprecated in drupal:10.1.0 and is removed from drupal:11.0.0. Configuration should be updated to accommodate the changes described at https://www.drupal.org/node/3279032.
```