### PR TITLE
Release 2.13.0

### DIFF
--- a/localgov_core.module
+++ b/localgov_core.module
@@ -13,6 +13,7 @@ function localgov_core_theme($existing, $type, $theme, $path) {
     'localgov_page_header_block' => [
       'variables' => [
         'title' => '',
+        'subtitle' => NULL,
         'lede' => NULL,
       ],
       'render element' => 'block',

--- a/src/Event/PageHeaderDisplayEvent.php
+++ b/src/Event/PageHeaderDisplayEvent.php
@@ -33,6 +33,13 @@ class PageHeaderDisplayEvent extends Event {
   protected $title = NULL;
 
   /**
+   * The page sub title override.
+   *
+   * @var array|string|null
+   */
+  protected $subTitle = NULL;
+
+  /**
    * Should the page header block be displayed?
    *
    * @var bool
@@ -101,6 +108,26 @@ class PageHeaderDisplayEvent extends Event {
    */
   public function setTitle($title) {
     $this->title = $title;
+  }
+
+  /**
+   * Sub title getter.
+   *
+   * @return array|string|null
+   *   The sub title.
+   */
+  public function getSubTitle() {
+    return $this->subTitle;
+  }
+
+  /**
+   * Sub title setter.
+   *
+   * @param array|string|null $sub_title
+   *   The sub title.
+   */
+  public function setSubTitle($sub_title) {
+    $this->subTitle = $sub_title;
   }
 
   /**

--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -70,6 +70,13 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   protected $title;
 
   /**
+   * The page subtitle override.
+   *
+   * @var array|string|null
+   */
+  protected $subTitle;
+
+  /**
    * The page lede override.
    *
    * @var array|string|null
@@ -149,6 +156,7 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
 
     // Set the title, lede, visibility and cache tags.
     $this->title = is_null($event->getTitle()) ? $this->getTitle() : $event->getTitle();
+    $this->subTitle = is_null($event->getSubTitle()) ? NULL : $event->getSubTitle();
     $this->lede = is_null($event->getLede()) ? $this->getLede() : $event->getLede();
     $this->visible = $event->getVisibility();
     $entityCacheTags = is_null($this->entity) ? [] : $this->entity->getCacheTags();
@@ -164,6 +172,7 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $build[] = [
       '#theme' => 'localgov_page_header_block',
       '#title' => $this->title,
+      '#subtitle' => $this->subTitle,
       '#lede' => $this->lede,
     ];
 

--- a/templates/localgov-page-header-block.html.twig
+++ b/templates/localgov-page-header-block.html.twig
@@ -15,7 +15,12 @@
 ] %}
 {% if title %}
 <div{{ attributes.addClass(classes) }}>
-  <h1 class="header">{{ title }}</h1>
+  <h1 class="header">
+    {{ title }}
+    {% if subtitle %}
+      <div class="header__subtitle">{{ subtitle }}</div>
+    {% endif %}
+  </h1>
   {% if lede %}
   <div class="subheader">{{ lede }}</div>
   {% endif %}

--- a/tests/localgov_core_page_header_event_test/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/tests/localgov_core_page_header_event_test/src/EventSubscriber/PageHeaderSubscriber.php
@@ -51,6 +51,13 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
       $event->setLede($parent->body->summary);
       $event->setCacheTags(Cache::mergeTags($node->getCacheTags(), $parent->getCacheTags()));
     }
+
+    // Set subtitle from parent, and cache tags from the parent for page4 nodes.
+    if ($node->bundle() == 'page4') {
+      $parent = $node->parent->entity;
+      $event->setSubTitle($parent->title->value);
+      $event->setCacheTags(Cache::mergeTags($node->getCacheTags(), $parent->getCacheTags()));
+    }
   }
 
 }


### PR DESCRIPTION
Adds the Subtitle header in #193

New minor release as this makes an api change.
If councils have made custom templates for `localgov-page-header-block.html.twig` and wish to use the new subtitle option they will need to be updated.