### PR TITLE
Define a constant for the user manager role

### DIFF
--- a/modules/localgov_roles/src/RolesHelper.php
+++ b/modules/localgov_roles/src/RolesHelper.php
@@ -23,6 +23,11 @@ class RolesHelper {
   const CONTRIBUTOR_ROLE = 'localgov_contributor';
 
   /**
+   * User manager role machine name.
+   */
+  const USER_MANAGER_ROLE = 'localgov_user_manager';
+
+  /**
    * Assign permissions to roles if module has defaults.
    */
   public static function assignModuleRoles($module) {


### PR DESCRIPTION
Fix #203

For completeness, define user manager role constant in RolesHelper for modules
that use hook_localgov_roles_default to also assign roles to the user manager.
