### PR TITLE
Override system 400 messages

### DIFF
--- a/localgov_core.services.yml
+++ b/localgov_core.services.yml
@@ -1,0 +1,5 @@
+services:
+  localgov_core.route_subscriber:
+    class: Drupal\localgov_core\EventSubscriber\SystemErrorPageRouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/src/Controller/Http4xxController.php
+++ b/src/Controller/Http4xxController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\localgov_core\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Returns responses for LocalGov Core routes.
+ */
+class Http4xxController extends ControllerBase
+{
+
+  /**
+   * The default 403 content.
+   *
+   * @return array
+   *   A render array containing the message to display for 403 pages.
+   */
+  public function on403()
+  {
+    return [
+        'message' => [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $this->t('You are not authorised to access this page.')
+        ],
+        'login_link' => [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes'=> [
+                'href'=> '/user/login'
+            ],
+            '#value' => $this->t('Login?')
+        ]
+    ];
+  }
+
+  /**
+   * The default 404 content.
+   *
+   * @return array
+   *   A render array containing the message to display for 404 pages.
+   */
+  public function on404()
+  {
+    return [
+        'message' => [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $this->t('The page you are requesting cannot be found.')
+        ],
+    ];
+  }
+
+}

--- a/src/EventSubscriber/SystemErrorPageRouteSubscriber.php
+++ b/src/EventSubscriber/SystemErrorPageRouteSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\localgov_core\EventSubscriber;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\Core\Routing\RoutingEvents;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Route subscriber.
+ */
+class SystemErrorPageRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('system.403')) {
+      $route->setDefault('_controller', '\Drupal\localgov_core\Controller\Http4xxController::on403');
+    }
+
+    if ($route = $collection->get('system.404')) {
+      $route->setDefault('_controller', '\Drupal\localgov_core\Controller\Http4xxController::on404');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events = parent::getSubscribedEvents();
+
+    // Use a lower priority than \Drupal\views\EventSubscriber\RouteSubscriber
+    // to ensure the requirement will be added to its routes.
+    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -300];
+
+    return $events;
+  }
+
+}


### PR DESCRIPTION
Overrides 404 and 403 system messages which have previously been hard-coded in localgov_base.

This relates to issue #218.