### PR TITLE
fix: additional strict type fixes

### DIFF
--- a/localgov_core.module
+++ b/localgov_core.module
@@ -25,10 +25,13 @@ function localgov_core_theme($existing, $type, $theme, $path) {
  * Implements hook_template_preprocess_default_variables_alter().
  */
 function localgov_core_template_preprocess_default_variables_alter(&$variables) {
-  if (theme_get_setting('localgov_base_remove_css')) {
+  $remove_css = (bool) theme_get_setting('localgov_base_remove_css');
+  $remove_js = (bool) theme_get_setting('localgov_base_remove_js');
+
+  if ($remove_css) {
     $variables['localgov_base_remove_css'] = TRUE;
   }
-  if (theme_get_setting('localgov_base_remove_js')) {
+  if ($remove_js) {
     $variables['localgov_base_remove_js'] = TRUE;
   }
 }

--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -130,24 +130,26 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $route = $this->currentRouteMatch->getRouteObject();
     if (!is_null($route)) {
       $parameters = $route->getOption('parameters');
-      foreach ($parameters as $name => $options) {
-        if (!isset($options['type'])) {
-          continue;
-        }
-
-        if (strpos($options['type'], 'entity:') === 0) {
-          $entity = $this->currentRouteMatch->getParameter($name);
-        }
-        elseif ($options['type'] === 'node_preview') {
-          $preview = $this->currentRouteMatch->getParentRouteMatch()->getParameter($name);
-          if (isset($preview->preview_view_mode) && $preview->preview_view_mode === 'full') {
-            $entity = $preview;
+      if (!is_null($parameters)) {
+        foreach ($parameters as $name => $options) {
+          if (!isset($options['type'])) {
+            continue;
           }
-        }
 
-        if (isset($entity) && $entity instanceof EntityInterface) {
-          $this->entity = $entity;
-          break;
+          if (strpos($options['type'], 'entity:') === 0) {
+            $entity = $this->currentRouteMatch->getParameter($name);
+          }
+          elseif ($options['type'] === 'node_preview') {
+            $preview = $this->currentRouteMatch->getParentRouteMatch()->getParameter($name);
+            if (isset($preview->preview_view_mode) && $preview->preview_view_mode === 'full') {
+              $entity = $preview;
+            }
+          }
+
+          if (isset($entity) && $entity instanceof EntityInterface) {
+            $this->entity = $entity;
+            break;
+          }
         }
       }
     }

--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -127,7 +127,9 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     //
     // We consider two cases: (1) type entity:*, and (2) type node_preview with
     // view_mode_id set to 'full'.
-    if (($route = $this->currentRouteMatch->getRouteObject()) && ($parameters = $route->getOption('parameters'))) {
+    $route = $this->currentRouteMatch->getRouteObject();
+    if (!is_null($route)) {
+      $parameters = $route->getOption('parameters');
       foreach ($parameters as $name => $options) {
         if (!isset($options['type'])) {
           continue;


### PR DESCRIPTION
Fixes the following errors, reported in https://github.com/localgovdrupal/localgov_project/pull/153

```
 ------ ------------------------------------------------------------ 
  Line   modules/contrib/localgov_core/localgov_core.module          
 ------ ------------------------------------------------------------ 
  28     Only booleans are allowed in an if condition, mixed given.  
  31     Only booleans are allowed in an if condition, mixed given.  
 ------ ------------------------------------------------------------ 

 ------ -------------------------------------------------------------------- 
  Line   modules/contrib/localgov_core/src/Plugin/Block/PageHeaderBlock.php  
 ------ -------------------------------------------------------------------- 
  130    Only booleans are allowed in &&, mixed given on the right side.     
 ------ -------------------------------------------------------------------- 
```