### PR TITLE
Do not call assignModuleRoles during config import.

### DIFF
--- a/modules/localgov_roles/localgov_roles.module
+++ b/modules/localgov_roles/localgov_roles.module
@@ -10,8 +10,10 @@ use Drupal\localgov_roles\RolesHelper;
 /**
  * Implements hook_modules_installed().
  */
-function localgov_roles_modules_installed($modules) {
-  foreach ($modules as $module) {
-    RolesHelper::assignModuleRoles($module);
+function localgov_roles_modules_installed($modules, $is_syncing) {
+  if (!$is_syncing) {
+    foreach ($modules as $module) {
+      RolesHelper::assignModuleRoles($module);
+    }
   }
 }


### PR DESCRIPTION
See https://github.com/localgovdrupal/localgov_core/issues/240
 
Installing LocalGov Publications using config import fails because `localgov_roles_modules_installed()` tries to add permissions before they exist - the new content type hasn't been imported yet. This probably applies to other LGD modules that create new content types.

## What does this change?

Change localgov_roles_modules_installed() to do nothing if $is_syncing is true.

## How to test

```
ddev drush si localgov -y
ddev export-db --file=lgd.sql.gz
ddev drush en localgov_publications
ddev drush cex
ddev import-db --file=lgd.sql.gz
ddev drush deploy
```

## How can we measure success?

No errors running `drush deploy`. 

The workaround is to run `drush config-import` again but isn't great when running pipelines. Also, is there a risk that the error stops other processes running which won't be attempted on the next config import?

## Have we considered potential risks?

 Can we assume that all permissions have been set already in config?