### PR TITLE
fix: upgrade metatag to recommended version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/image_widget_crop": "^2.3",
         "drupal/linkit": "^6.0-beta1",
         "drupal/media_library_edit": "^3.0",
-        "drupal/metatag": "^1.14",
+        "drupal/metatag": "^2.0.2",
         "drupal/pathauto": "^1.8",
         "drupal/role_delegation": "^1.1",
         "drupal/token": "^1.7"


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Upgrade metatag contrib module to the version recommended by the maintainer https://www.drupal.org/project/metatag.

This also gives support for Drupal core ^9.4 || ^10 || ^11

This is dependent on this PR https://github.com/localgovdrupal/localgov_news/pull/123

## How to test
```
composer require --with-all-dependencies localgovdrupal/localgov_core:"dev-fix/2.x/upgrade-metatag as 2.13.7" localgovdrupal/localgov_news:"dev-fix/2.x/update-schema-metatag as 2.3.8"
```