### PR TITLE
Fix/2.x/245 installing site from existing config fails

### DIFF
--- a/localgov_core.module
+++ b/localgov_core.module
@@ -44,7 +44,12 @@ function localgov_core_template_preprocess_default_variables_alter(&$variables) 
  * This installs default blocks for modules when they're enabled on an existing
  * site. (IE, not in the installer.)
  */
-function localgov_core_modules_installed(array $modules): void {
+function localgov_core_modules_installed(array $modules, bool $is_syncing): void {
+
+  if ($is_syncing) {
+    return;
+  }
+
   // If we're in the installer, do nothing.
   if (InstallerKernel::installationAttempted()) {
     return;

--- a/src/Service/DefaultBlockInstaller.php
+++ b/src/Service/DefaultBlockInstaller.php
@@ -117,6 +117,7 @@ class DefaultBlockInstaller {
   protected function installForModule(string $module): void {
 
     $blocks = $this->blockDefinitions($module);
+    $blockStorage = $this->entityTypeManager->getStorage('block');
 
     // Loop over every theme and block definition, so we set up all the blocks
     // in all the relevant themes.
@@ -131,10 +132,10 @@ class DefaultBlockInstaller {
         $block['id'] = $this->sanitiseId($theme . '_' . $block['plugin']);
         $block['theme'] = $theme;
 
-        $this->entityTypeManager
-          ->getStorage('block')
-          ->create($block)
-          ->save();
+        // If there's no block with this ID already, create and save this block.
+        if ($blockStorage->load($block['id']) === NULL) {
+          $blockStorage->create($block)->save();
+        }
       }
     }
   }


### PR DESCRIPTION
Checks if a block with the derived ID of a new block exists before trying to save a new block.

Adds and checks the $is_syncing param of hook_modules_installed().

Fix for #245 