### PR TITLE
adds documents to linkit profile

### DIFF
--- a/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
+++ b/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
@@ -3,23 +3,47 @@ status: true
 dependencies:
   module:
     - node
-id: default
+    - paragraphs_library
 label: Default
+id: default
 description: 'A default Linkit profile'
 matchers:
   556010a3-e317-48b3-b4ed-854c10f4b950:
-    uuid: 556010a3-e317-48b3-b4ed-854c10f4b950
     id: 'entity:node'
-    weight: 0
+    uuid: 556010a3-e317-48b3-b4ed-854c10f4b950
     settings:
       metadata: ''
       bundles: {  }
       group_by_bundle: true
-      include_unpublished: false
       substitution_type: canonical
       limit: 100
+      include_unpublished: false
+    weight: -10
   c3257417-fce9-4307-8251-58672edf88be:
-    uuid: c3257417-fce9-4307-8251-58672edf88be
     id: email
-    weight: 0
+    uuid: c3257417-fce9-4307-8251-58672edf88be
     settings: {  }
+    weight: -8
+  ce6c1f02-c84f-45b9-a8cd-5ca4901ff1e5:
+    id: 'entity:paragraphs_library_item'
+    uuid: ce6c1f02-c84f-45b9-a8cd-5ca4901ff1e5
+    settings:
+      metadata: ''
+      bundles:
+        localgov_contact: localgov_contact
+        localgov_link: localgov_link
+      group_by_bundle: true
+      substitution_type: paragraphs_library_item_localgovdrupal
+      limit: 20
+    weight: -7
+  9f1a0ab1-0e93-4a64-be91-34356fd3c742:
+    id: 'entity:media'
+    uuid: 9f1a0ab1-0e93-4a64-be91-34356fd3c742
+    settings:
+      metadata: '[media:bundle] | [media:name]'
+      bundles:
+        document: document
+      group_by_bundle: true
+      substitution_type: canonical
+      limit: 100
+    weight: -9

--- a/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
+++ b/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
@@ -44,6 +44,6 @@ matchers:
       bundles:
         document: document
       group_by_bundle: true
-      substitution_type: canonical
+      substitution_type: media
       limit: 100
     weight: -9


### PR DESCRIPTION
Closes #253 

## What does this change?

- Adds documents as an allowed type in the LinkIt matchers.
- Sets the URL to be "canonical" (/media/123 - I think). Would we prefer this to be "Direct link to the media file"?

## How to test

Try to link to a document in a wysiwyg, you should see "Document: [media - name]" for available documents in your linkit suggestions.

## Have we considered potential risks?

I'm not fully sure what happens when a document is changed/gets a new file.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.