### PR TITLE
Add a view display extender for the localgov_page_header for the lede

### DIFF
--- a/config/schema/localgov_core.views.schema.yml
+++ b/config/schema/localgov_core.views.schema.yml
@@ -1,0 +1,9 @@
+views.display_extender.localgov_page_header_display_extender:
+  type: views_display_extender
+  mapping:
+    lede:
+      type: text
+      label: 'Lede'
+    tokenize:
+      type: boolean
+      label: 'Should replacement tokens be used from the first row'

--- a/localgov_core.info.yml
+++ b/localgov_core.info.yml
@@ -8,6 +8,7 @@ dependencies:
   - drupal:block
   - drupal:field
   - drupal:node
+  - drupal:views
   - field_group:field_group
 
 test_dependencies:

--- a/localgov_core.install
+++ b/localgov_core.install
@@ -10,7 +10,7 @@ use Drupal\localgov_core\FieldRenameHelper;
 /**
  * Implements hook_install().
  */
-function localgov_core_install() {
+function localgov_core_install(): void {
   _localgov_core_enabled_views_page_display_extender();
 }
 
@@ -106,14 +106,14 @@ function localgov_core_update_8004() {
 /**
  * Enables the views page header display extender.
  */
-function localgov_core_update_8005() {
+function localgov_core_update_8005(): void {
   _localgov_core_enabled_views_page_display_extender();
 }
 
 /**
  * Enable localgov_page_header_display_extender plugin.
  */
-function _localgov_core_enabled_views_page_display_extender() {
+function _localgov_core_enabled_views_page_display_extender(): void {
   $config = \Drupal::service('config.factory')->getEditable('views.settings');
   $display_extenders = $config->get('display_extenders') ?: [];
   $display_extenders[] = 'localgov_page_header_display_extender';

--- a/localgov_core.install
+++ b/localgov_core.install
@@ -8,6 +8,13 @@
 use Drupal\localgov_core\FieldRenameHelper;
 
 /**
+ * Implements hook_install().
+ */
+function localgov_core_install() {
+  _localgov_core_enabled_views_page_display_extender();
+}
+
+/**
  * Update Field names for localgov_core provided fields.
  *
  * Field mapping between existing and new names:
@@ -93,5 +100,23 @@ function localgov_core_update_8004() {
   $config->set('display.page_2.display_options.path', 'admin/content/media/files/usage/%');
 
   // Save the configuration.
+  $config->save();
+}
+
+/**
+ * Enables the views page header display extender.
+ */
+function localgov_core_update_8005() {
+  _localgov_core_enabled_views_page_display_extender();
+}
+
+/**
+ * Enable localgov_page_header_display_extender plugin.
+ */
+function _localgov_core_enabled_views_page_display_extender() {
+  $config = \Drupal::service('config.factory')->getEditable('views.settings');
+  $display_extenders = $config->get('display_extenders') ?: [];
+  $display_extenders[] = 'localgov_page_header_display_extender';
+  $config->set('display_extenders', $display_extenders);
   $config->save();
 }

--- a/src/Event/PageHeaderDisplayEvent.php
+++ b/src/Event/PageHeaderDisplayEvent.php
@@ -3,6 +3,8 @@
 namespace Drupal\localgov_core\Event;
 
 use Drupal\Component\EventDispatcher\Event;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\views\ViewExecutable;
 
 /**
  * Event that is fired when displaying the page header.
@@ -17,6 +19,13 @@ class PageHeaderDisplayEvent extends Event {
    * @var \Drupal\Core\Entity\EntityInterface|null
    */
   protected $entity = NULL;
+
+  /**
+   * View executable associated with the current route.
+   *
+   * @var \Drupal\views\ViewExecutable|null
+   */
+  protected $view = NULL;
 
   /**
    * The page lede override.
@@ -56,7 +65,10 @@ class PageHeaderDisplayEvent extends Event {
   /**
    * {@inheritdoc}
    */
-  public function __construct($entity) {
+  public function __construct($entity = NULL) {
+    // @todo remove the $entity paramater or deprecate it.
+    // Since we should use the setters and getters.
+    // Or we can mark this class as internal?
     $this->entity = $entity;
   }
 
@@ -66,8 +78,38 @@ class PageHeaderDisplayEvent extends Event {
    * @return \Drupal\Core\Entity\EntityInterface|null
    *   The entity.
    */
-  public function getEntity() {
+  public function getEntity() : ?EntityInterface {
     return $this->entity;
+  }
+
+  /**
+   * Entity setter.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   */
+  public function setEntity(EntityInterface $entity) : void {
+    $this->entity = $entity;
+  }
+
+  /**
+   * View getter.
+   *
+   * @return \Drupal\views\ViewExecutable|null
+   *   The view.
+   */
+  public function getView() : ?ViewExecutable {
+    return $this->view;
+  }
+
+  /**
+   * View setter.
+   *
+   * @param \Drupal\views\ViewExecutable $view
+   *   The view.
+   */
+  public function setView(ViewExecutable $view) {
+    $this->view = $view;
   }
 
   /**

--- a/src/Event/PageHeaderDisplayEvent.php
+++ b/src/Event/PageHeaderDisplayEvent.php
@@ -108,7 +108,7 @@ class PageHeaderDisplayEvent extends Event {
    * @param \Drupal\views\ViewExecutable $view
    *   The view.
    */
-  public function setView(ViewExecutable $view) {
+  public function setView(ViewExecutable $view) : void {
     $this->view = $view;
   }
 

--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -178,12 +178,12 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
 
     // If an entity is set, pass to the event.
     if ($this->entity instanceof EntityInterface) {
-      $event->setEntity($entity);
+      $event->setEntity($this->entity);
     }
 
     // If a view is set, pass to the event.
     if ($this->view instanceof ViewExecutable) {
-      $event->setView($view);
+      $event->setView($this->view);
     }
 
     // Dispatch event.
@@ -259,6 +259,8 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     // Return view custom summary.
     if ($this->view instanceof ViewExecutable) {
       $extender = $this->view->getDisplay()->getExtenders()['localgov_page_header_display_extender'] ?? NULL;
+
+      // Need to render view to apply tokens.
       $this->view->render();
       $lede = $extender->getLede();
       return [

--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -65,6 +65,13 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   protected $entity = NULL;
 
   /**
+   * View executable associated with the current route.
+   *
+   * @var \Drupal\views\ViewExecutable|null
+   */
+  protected $view = NULL;
+
+  /**
    * The page title override.
    *
    * @var array|string|null
@@ -155,17 +162,31 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
           }
         }
       }
+
+      // If this is a view path, set the view instead.
       if (isset($defaults['view_id']) && isset($defaults['display_id'])) {
         $view = Views::getView($defaults['view_id']);
         if ($view) {
           $view->setDisplay($defaults['display_id']);
-          $this->entity = $view;
+          $this->view = $view;
         }
       }
     }
 
     // Dispatch event to allow modules to alter block content.
-    $event = new PageHeaderDisplayEvent($this->entity);
+    $event = new PageHeaderDisplayEvent();
+
+    // If an entity is set, pass to the event.
+    if ($this->entity instanceof EntityInterface) {
+      $event->setEntity($entity);
+    }
+
+    // If a view is set, pass to the event.
+    if ($this->view instanceof ViewExecutable) {
+      $event->setView($view);
+    }
+
+    // Dispatch event.
     $this->eventDispatcher->dispatch($event, PageHeaderDisplayEvent::EVENT_NAME);
 
     // Set the title, lede, visibility and cache tags.
@@ -174,7 +195,8 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $this->lede = is_null($event->getLede()) ? $this->getLede() : $event->getLede();
     $this->visible = $event->getVisibility();
     $entityCacheTags = is_null($this->entity) ? [] : $this->entity->getCacheTags();
-    $this->cacheTags = is_null($event->getCacheTags()) ? $entityCacheTags : $event->getCacheTags();
+    $viewCacheTags = is_null($this->view) ? [] : $this->view->getCacheTags();
+    $this->cacheTags = is_null($event->getCacheTags()) ? array_merge($entityCacheTags, $viewCacheTags) : $event->getCacheTags();
   }
 
   /**
@@ -235,9 +257,9 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     }
 
     // Return view custom summary.
-    if ($this->entity instanceof ViewExecutable) {
-      $extender = $this->entity->getDisplay()->getExtenders()['localgov_page_header_display_extender'] ?? NULL;
-      $this->entity->render();
+    if ($this->view instanceof ViewExecutable) {
+      $extender = $this->view->getDisplay()->getExtenders()['localgov_page_header_display_extender'] ?? NULL;
+      $this->view->render();
       $lede = $extender->getLede();
       return [
         '#type' => 'html_tag',

--- a/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
+++ b/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
@@ -37,7 +37,7 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    /** @var \Drupal\metatag_views\Plugin\views\display_extender\MetatagDisplayExtender */
+    /** @var \Drupal\localgov_core\Plugin\views\display_extender\PageHeaderDisplayExtender */
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
 
     return $instance;

--- a/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
+++ b/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
@@ -11,7 +11,7 @@ use Drupal\views\ViewExecutable;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Metatag display extender plugin.
+ * Localgov page header display extender plugin.
  *
  * @ingroup views_display_extender_plugins
  *

--- a/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
+++ b/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Drupal\localgov_core\Plugin\views\display_extender;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\views\Plugin\views\display_extender\DisplayExtenderPluginBase;
+use Drupal\views\Plugin\views\style\StylePluginBase;
+use Drupal\views\ViewExecutable;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Metatag display extender plugin.
+ *
+ * @ingroup views_display_extender_plugins
+ *
+ * @ViewsDisplayExtender(
+ *   id = "localgov_page_header_display_extender",
+ *   title = @Translation("Page header display extender"),
+ *   help = @Translation("Page header settings for this view."),
+ *   no_ui = FALSE
+ * )
+ */
+class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
+
+  use StringTranslationTrait;
+
+  /**
+   * The first row tokens on the style plugin.
+   *
+   * @var array
+   */
+  protected static $firstRowTokens;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var \Drupal\metatag_views\Plugin\views\display_extender\MetatagDisplayExtender */
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+
+    $options['lede'] = ['default' => ''];
+    $options['tokenize'] = ['default' => FALSE];
+
+    return $options;
+  }
+
+  /**
+   * Provide a form to edit options for this plugin.
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+
+    if ($form_state->get('section') == 'page_header') {
+      $form['#title'] .= $this->t('The page header summary');
+
+      // Build/inject the Metatag form.
+      $form['lede'] = [
+        '#type' => 'textarea',
+        '#title' => $this->t('Lede'),
+        '#description' => $this->t('Summary displayed under the page title.'),
+        '#default_value' => $this->options['lede'],
+      ];
+      $this->tokenForm($form['page_header'], $form_state);
+    }
+  }
+
+  /**
+   * Handle any special handling on the validate form.
+   */
+  public function submitOptionsForm(&$form, FormStateInterface $form_state) {
+    if ($form_state->get('section') == 'page_header') {
+      // Process submitted metatag values and remove empty tags.
+      $page_header_values = $form_state->cleanValues()->getValues();
+      $this->options['tokenize'] = $page_header_values['tokenize'] ?? FALSE;
+      unset($page_header_values['tokenize']);
+      $this->options['lede'] = $page_header_values['lede'];
+    }
+  }
+
+  /**
+   * Verbatim copy of TokenizeAreaPluginBase::tokenForm().
+   */
+  public function tokenForm(&$form, FormStateInterface $form_state) {
+    $form['tokenize'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Use replacement tokens from the first row'),
+      '#default_value' => $this->options['tokenize'],
+    ];
+
+    // Get a list of the available fields and arguments for token replacement.
+    $options = [];
+    $optgroup_arguments = (string) new TranslatableMarkup('Arguments');
+    $optgroup_fields = (string) new TranslatableMarkup('Fields');
+    foreach ($this->view->display_handler->getHandlers('field') as $field => $handler) {
+      $options[$optgroup_fields]["{{ $field }}"] = $handler->adminLabel();
+    }
+
+    foreach ($this->view->display_handler->getHandlers('argument') as $arg => $handler) {
+      $options[$optgroup_arguments]["{{ arguments.$arg }}"] = $this->t('@argument title', ['@argument' => $handler->adminLabel()]);
+      $options[$optgroup_arguments]["{{ raw_arguments.$arg }}"] = $this->t('@argument input', ['@argument' => $handler->adminLabel()]);
+    }
+
+    if (!empty($options)) {
+      $form['tokens'] = [
+        '#type' => 'details',
+        '#title' => $this->t('Replacement patterns'),
+        '#open' => TRUE,
+        '#id' => 'edit-options-token-help',
+        '#states' => [
+          'visible' => [
+            ':input[name="options[tokenize]"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
+      $form['tokens']['help'] = [
+        '#markup' => '<p>' . $this->t('The following tokens are available. You may use Twig syntax in this field.') . '</p>',
+      ];
+      foreach (array_keys($options) as $type) {
+        if (!empty($options[$type])) {
+          $items = [];
+          foreach ($options[$type] as $key => $value) {
+            $items[] = $key . ' == ' . $value;
+          }
+          $form['tokens'][$type]['tokens'] = [
+            '#theme' => 'item_list',
+            '#items' => $items,
+          ];
+        }
+      }
+    }
+
+    $this->globalTokenForm($form, $form_state);
+  }
+
+  /**
+   * Provide the default summary for options in the views UI.
+   *
+   * This output is returned as an array.
+   */
+  public function optionsSummary(&$categories, &$options) {
+    $categories['page_header'] = [
+      'title' => $this->t('Page header'),
+      'column' => 'second',
+    ];
+    $options['page_header'] = [
+      'category' => 'page_header',
+      'title' => $this->t('Page header'),
+      'value' => $this->options['lede'] ? $this->t('Custom lede') : $this->t('No lede'),
+    ];
+  }
+
+  /**
+   * Lists defaultable sections and items contained in each section.
+   */
+  public function defaultableSections(&$sections, $section = NULL) {
+  }
+
+  /**
+   * Get the lede for display.
+   *
+   * @param bool $raw
+   *   Flag if to return raw (untokenised) output.
+   *
+   * @return string
+   *   Lede for display.
+   */
+  public function getLede(bool $raw = FALSE) : string {
+    $view = $this->view;
+    $lede = '';
+
+    if (!empty($this->options['lede'])) {
+      $lede = $this->options['lede'];
+    }
+
+    if ($this->options['lede'] && !$raw) {
+      if (!empty(self::$firstRowTokens[$view->current_display])) {
+        self::setFirstRowTokensOnStylePlugin($view, self::$firstRowTokens[$view->current_display]);
+      }
+      // This is copied from TokenizeAreaPluginBase::tokenizeValue().
+      $style = $view->getStyle();
+      $lede = $style->tokenizeValue($lede, 0);
+      $lede = $this->globalTokenReplace($lede);
+    }
+
+    return $lede;
+  }
+
+  /**
+   * Store first row tokens on the class.
+   *
+   * The function metatag_views_metatag_route_entity() loads the View fresh, to
+   * avoid rebuilding and re-rendering it, preserve the first row tokens.
+   */
+  public function setFirstRowTokens(array $first_row_tokens) {
+    self::$firstRowTokens[$this->view->current_display] = $first_row_tokens;
+  }
+
+  /**
+   * Set the first row tokens on the style plugin.
+   *
+   * @param \Drupal\views\ViewExecutable $view
+   *   The view.
+   * @param array $first_row_tokens
+   *   The first row tokens.
+   */
+  public static function setFirstRowTokensOnStylePlugin(ViewExecutable $view, array $first_row_tokens) {
+    $style = $view->getStyle();
+    self::getFirstRowTokensReflection($style)->setValue($style, [$first_row_tokens]);
+  }
+
+  /**
+   * Get the first row tokens from the style plugin.
+   *
+   * @param \Drupal\views\ViewExecutable $view
+   *   The view.
+   *
+   * @return array
+   *   The first row tokens.
+   */
+  public static function getFirstRowTokensFromStylePlugin(ViewExecutable $view) {
+    $style = $view->getStyle();
+    return self::getFirstRowTokensReflection($style)->getValue($style)[0] ?? [];
+  }
+
+  /**
+   * Get the first row tokens for this Views object iteration.
+   *
+   * @param \Drupal\views\Plugin\views\style\StylePluginBase $style
+   *   The style plugin used for this request.
+   *
+   * @return \ReflectionProperty
+   *   The rawTokens property.
+   */
+  protected static function getFirstRowTokensReflection(StylePluginBase $style): \ReflectionProperty {
+    $r = new \ReflectionObject($style);
+    $p = $r->getProperty('rowTokens');
+    $p->setAccessible(TRUE);
+    return $p;
+  }
+
+}

--- a/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
+++ b/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
@@ -58,7 +58,7 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
   /**
    * Provide a form to edit options for this plugin.
    */
-  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+  public function buildOptionsForm(&$form, FormStateInterface $form_state): void {
 
     if ($form_state->get('section') == 'page_header') {
       $form['#title'] .= $this->t('The page header summary');
@@ -77,7 +77,7 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
   /**
    * Handle any special handling on the validate form.
    */
-  public function submitOptionsForm(&$form, FormStateInterface $form_state) {
+  public function submitOptionsForm(&$form, FormStateInterface $form_state): void {
     if ($form_state->get('section') == 'page_header') {
       // Process submitted metatag values and remove empty tags.
       $page_header_values = $form_state->cleanValues()->getValues();
@@ -90,7 +90,7 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
   /**
    * Verbatim copy of TokenizeAreaPluginBase::tokenForm().
    */
-  public function tokenForm(&$form, FormStateInterface $form_state) {
+  public function tokenForm(&$form, FormStateInterface $form_state): void {
     $form['tokenize'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Use replacement tokens from the first row'),
@@ -147,7 +147,7 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
    *
    * This output is returned as an array.
    */
-  public function optionsSummary(&$categories, &$options) {
+  public function optionsSummary(&$categories, &$options): void {
     $categories['page_header'] = [
       'title' => $this->t('Page header'),
       'column' => 'second',
@@ -157,12 +157,6 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
       'title' => $this->t('Page header'),
       'value' => $this->options['lede'] ? $this->t('Custom lede') : $this->t('No lede'),
     ];
-  }
-
-  /**
-   * Lists defaultable sections and items contained in each section.
-   */
-  public function defaultableSections(&$sections, $section = NULL) {
   }
 
   /**
@@ -201,7 +195,7 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
    * The function metatag_views_metatag_route_entity() loads the View fresh, to
    * avoid rebuilding and re-rendering it, preserve the first row tokens.
    */
-  public function setFirstRowTokens(array $first_row_tokens) {
+  public function setFirstRowTokens(array $first_row_tokens): void {
     self::$firstRowTokens[$this->view->current_display] = $first_row_tokens;
   }
 
@@ -213,7 +207,7 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
    * @param array $first_row_tokens
    *   The first row tokens.
    */
-  public static function setFirstRowTokensOnStylePlugin(ViewExecutable $view, array $first_row_tokens) {
+  public static function setFirstRowTokensOnStylePlugin(ViewExecutable $view, array $first_row_tokens): void {
     $style = $view->getStyle();
     self::getFirstRowTokensReflection($style)->setValue($style, [$first_row_tokens]);
   }
@@ -227,7 +221,7 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
    * @return array
    *   The first row tokens.
    */
-  public static function getFirstRowTokensFromStylePlugin(ViewExecutable $view) {
+  public static function getFirstRowTokensFromStylePlugin(ViewExecutable $view): array {
     $style = $view->getStyle();
     return self::getFirstRowTokensReflection($style)->getValue($style)[0] ?? [];
   }

--- a/tests/localgov_core_views_page_header_test/config/install/views.view.recent_content.yml
+++ b/tests/localgov_core_views_page_header_test/config/install/views.view.recent_content.yml
@@ -1,0 +1,214 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+  module:
+    - node
+    - user
+id: recent_content
+label: 'Recent content'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Recent content'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: true
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders:
+        localgov_page_header_display_extender:
+          lede: 'The most recent 10 pages that have been created on [site:name], including {{ title|striptags }}'
+          tokenize: true
+      path: recent-content
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_2:
+    id: page_2
+    display_title: 'Page 2'
+    display_plugin: page
+    position: 2
+    display_options:
+      title: 'Old content'
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      defaults:
+        title: false
+        sorts: false
+      display_extenders:
+        localgov_page_header_display_extender:
+          lede: 'The oldest 10 pages that have been created on [site:name], including {{ title|striptags }}'
+          tokenize: true
+      path: oldest-content
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/tests/localgov_core_views_page_header_test/localgov_core_views_page_header_test.info.yml
+++ b/tests/localgov_core_views_page_header_test/localgov_core_views_page_header_test.info.yml
@@ -1,0 +1,9 @@
+name: 'Views page header test'
+type: module
+package: Testing
+core_version_requirement: ^10 || ^11
+description: Testing module for the views page header display extender.
+dependencies:
+  - drupal:node
+  - drupal:views
+  - localgov_core:localgov_core

--- a/tests/src/Functional/ViewsPageExtenderTest.php
+++ b/tests/src/Functional/ViewsPageExtenderTest.php
@@ -40,7 +40,7 @@ class ViewsPageExtenderTest extends BrowserTestBase {
   /**
    * Test block display.
    */
-  public function testViewWithPageHeadeExtender() {
+  public function testViewWithPageHeadeExtender(): void {
 
     // Check node title and summary display on a page.
     $this->createContentType(['type' => 'page']);

--- a/tests/src/Functional/ViewsPageExtenderTest.php
+++ b/tests/src/Functional/ViewsPageExtenderTest.php
@@ -34,15 +34,6 @@ class ViewsPageExtenderTest extends BrowserTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-
-    // Enable localgov_page_header_display_extender plugin.
-    // @todo do this in the module install.
-    $config = \Drupal::service('config.factory')->getEditable('views.settings');
-    $display_extenders = $config->get('display_extenders') ?: [];
-    $display_extenders[] = 'localgov_page_header_display_extender';
-    $config->set('display_extenders', $display_extenders);
-    $config->save();
-
     $this->drupalPlaceBlock('localgov_page_header_block');
   }
 

--- a/tests/src/Functional/ViewsPageExtenderTest.php
+++ b/tests/src/Functional/ViewsPageExtenderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\Tests\localgov_core\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\taxonomy\Traits\TaxonomyTestTrait;
+use Drupal\node\NodeInterface;
+
+/**
+ * Functional tests for LocalGovDrupal install profile.
+ */
+class ViewsPageExtenderTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+  use TaxonomyTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'localgov_core',
+    'localgov_core_views_page_header_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Enable localgov_page_header_display_extender plugin.
+    // @todo do this in the module install.
+    $config = \Drupal::service('config.factory')->getEditable('views.settings');
+    $display_extenders = $config->get('display_extenders') ?: [];
+    $display_extenders[] = 'localgov_page_header_display_extender';
+    $config->set('display_extenders', $display_extenders);
+    $config->save();
+
+    $this->drupalPlaceBlock('localgov_page_header_block');
+  }
+
+  /**
+   * Test block display.
+   */
+  public function testViewWithPageHeadeExtender() {
+
+    // Check node title and summary display on a page.
+    $this->createContentType(['type' => 'page']);
+
+    $node = [];
+    for ($i = 1; $i <= 10; $i++) {
+      $node[] = $this->createNode([
+        'type' => 'page',
+        'title' => 'page ' . $i . ' title',
+        'status' => NodeInterface::PUBLISHED,
+        'created' => strtotime('Now -' . (10 - $i) . ' days'),
+      ]);
+    }
+
+    $first_node = reset($node);
+    $last_node = end($node);
+    $site_name = \Drupal::config('system.site')->get('name');
+
+    $this->drupalGet('/recent-content');
+    $this->assertSession()->pageTextContains('The most recent 10 pages that have been created on ' . $site_name . ', including ' . $last_node->getTitle());
+
+    $this->drupalGet('/oldest-content');
+    $this->assertSession()->pageTextContains('The oldest 10 pages that have been created on ' . $site_name . ', including ' . $first_node->getTitle());
+
+  }
+
+}


### PR DESCRIPTION
Fix #127
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Adds a setting to views that allows for a page header category, with the option
to set a custom lede inside the view, which will then be used by the
page header block.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test
1. Enable the new page header display extender on /admin/structure/views/settings/advanced (should we enable this by default?)
2. Create a new view with a page display.
3. There should be a new page header section in the center of the views configuration.
4. Edit that and add some summary text, you should also be able to use tokens from the view.
5. View the views page, and the page header should also display the entered summary as the lede (part of the page header block).

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->
Now possible for site builders to add subtitles to views.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

May conflict with others who have added their own extension to get a subtitle on the view.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

<img width="1232" alt="Screenshot 2024-11-13 at 9 47 10 am" src="https://github.com/user-attachments/assets/c0fd2e34-3bdb-4502-87d1-49a58c633c1a">

<img width="474" alt="Screenshot 2024-11-13 at 9 52 19 am" src="https://github.com/user-attachments/assets/bbe8d984-c582-4c66-a6df-fb5850bfc1ce">

<img width="1048" alt="Screenshot 2024-11-13 at 9 52 23 am" src="https://github.com/user-attachments/assets/347a6aa5-9582-4cab-895f-d11d0ad9f791">


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)