### PR TITLE
Drupal 11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@1.x
+    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@feature/1.x/d11-support
     with:
       project: 'localgovdrupal/localgov_core'
       project_path: 'web/modules/contrib/localgov_core'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@feature/1.x/d11-support
+    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@1.x
     with:
       project: 'localgovdrupal/localgov_core'
       project_path: 'web/modules/contrib/localgov_core'

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
         "composer-exit-on-patch-failure": true,
         "patchLevel": {
             "drupal/core": "-p2"
+        },
+        "patches": {
+            "drupal/field_group": {
+                "Nullable types #3490746": "https://git.drupalcode.org/project/field_group/-/commit/23540687517e3afee192f08f1c32a40d69f2dfa7.patch"
+            }
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,15 @@
         "patches": {
             "drupal/field_group": {
                 "Nullable types #3490746": "https://git.drupalcode.org/project/field_group/-/commit/23540687517e3afee192f08f1c32a40d69f2dfa7.patch"
+            },
+            "drupal/linkit": {
+                "Nullable types #3498223": "https://git.drupalcode.org/project/linkit/-/commit/ac89690051fbfa4e19b0e3df41e3ba628d199d2e.patch"
+            },
+            "drupal/paragraphs": {
+                "Nullable types #3492419": "https://git.drupalcode.org/project/paragraphs/-/commit/9efaadd62448fc847f9860a2066d81c3039daa07.patch"
+            },
+            "drupal/role_delegation": {
+                "Nullable types #3499682": "https://git.drupalcode.org/project/role_delegation/-/commit/f21be7a1f66de4a095c1398d9a53aa44bdad3524.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/field_group": "^3.1",
         "drupal/image_widget_crop": "^2.3",
-        "drupal/linkit": "^6.0-beta1",
+        "drupal/linkit": "^7.0",
         "drupal/media_library_edit": "^3.0",
         "drupal/metatag": "^2.0.2",
         "drupal/pathauto": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,6 @@
             "drupal/field_group": {
                 "Nullable types #3490746": "https://git.drupalcode.org/project/field_group/-/commit/23540687517e3afee192f08f1c32a40d69f2dfa7.patch"
             },
-            "drupal/linkit": {
-                "Nullable types #3498223": "https://git.drupalcode.org/project/linkit/-/commit/ac89690051fbfa4e19b0e3df41e3ba628d199d2e.patch"
-            },
             "drupal/paragraphs": {
                 "Nullable types #3492419": "https://git.drupalcode.org/project/paragraphs/-/commit/9efaadd62448fc847f9860a2066d81c3039daa07.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/field_group": "^3.1",
         "drupal/image_widget_crop": "^2.3",
-        "drupal/linkit": "^7.0",
+        "drupal/linkit": "^6.1 || ^7.0",
         "drupal/media_library_edit": "^3.0",
         "drupal/metatag": "^2.0.2",
         "drupal/pathauto": "^1.8",

--- a/localgov_core.info.yml
+++ b/localgov_core.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Core
 description: LocalGov Drupal helper functions and core dependencies.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^10.1
+core_version_requirement: ^10.1 || ^11
 
 dependencies:
   - drupal:block

--- a/modules/localgov_admin_theme_improvements/localgov_admin_theme_improvements.info.yml
+++ b/modules/localgov_admin_theme_improvements/localgov_admin_theme_improvements.info.yml
@@ -2,4 +2,4 @@ name: LocalGov Admin Theme Improvements
 type: module
 description: 'Small items to fix issues with the admin theme.'
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11

--- a/modules/localgov_media/localgov_media.info.yml
+++ b/modules/localgov_media/localgov_media.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Media
 description: LocalGov Media configuration.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - drupal:ckeditor5

--- a/modules/localgov_media/tests/src/Functional/StandardProfileTest.php
+++ b/modules/localgov_media/tests/src/Functional/StandardProfileTest.php
@@ -19,11 +19,11 @@ class StandardProfileTest extends BrowserTestBase {
   protected $profile = 'standard';
 
   /**
-   * Test locagov_media installs with the Standard profile.
+   * Test localgov_media installs with the Standard profile.
    */
   public function testEnablingLocalGovMedia() {
-
     \Drupal::service('module_installer')->install(['localgov_media']);
+    $this->assertTrue(\Drupal::service('module_handler')->moduleExists('localgov_media'));
   }
 
 }

--- a/modules/localgov_roles/localgov_roles.info.yml
+++ b/modules/localgov_roles/localgov_roles.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Roles
 description: Default user roles.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - drupal:path

--- a/modules/localgov_roles/tests/modules/localgov_roles_test_one/localgov_roles_test_one.info.yml
+++ b/modules/localgov_roles/tests/modules/localgov_roles_test_one/localgov_roles_test_one.info.yml
@@ -2,5 +2,5 @@ name: 'LocalGov Roles Test Helper 1'
 type: module
 description: 'Support module for LocalGov Roles tests'
 package: Testing
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 hidden: true

--- a/modules/localgov_roles/tests/modules/localgov_roles_test_two/localgov_roles_test_two.info.yml
+++ b/modules/localgov_roles/tests/modules/localgov_roles_test_two/localgov_roles_test_two.info.yml
@@ -2,5 +2,5 @@ name: 'LocalGov Roles Test Helper 2'
 type: module
 description: 'Support module for LocalGov Roles tests'
 package: Testing
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 hidden: true

--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\localgov_core\Plugin\Block;
 
-use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
@@ -15,6 +14,7 @@ use Drupal\localgov_core\Event\PageHeaderDisplayEvent;
 use Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -37,7 +37,7 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   /**
    * Core event_dispatcher service.
    *
-   * @var \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
    */
   protected $eventDispatcher;
 
@@ -115,7 +115,7 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $current_route_match, ContainerAwareEventDispatcher $event_dispatcher, RequestStack $request_stack, TitleResolver $title_resolver) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $current_route_match, EventDispatcherInterface $event_dispatcher, RequestStack $request_stack, TitleResolver $title_resolver) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->currentRouteMatch = $current_route_match;

--- a/tests/localgov_core_default_blocks_test/localgov_core_default_blocks_test.info.yml
+++ b/tests/localgov_core_default_blocks_test/localgov_core_default_blocks_test.info.yml
@@ -1,5 +1,5 @@
 name: 'Default blocks test'
 type: module
 package: Testing
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 description: Testing module for default blocks.

--- a/tests/localgov_core_page_header_event_test/localgov_core_page_header_event_test.info.yml
+++ b/tests/localgov_core_page_header_event_test/localgov_core_page_header_event_test.info.yml
@@ -1,5 +1,5 @@
 name: 'Page header display event test'
 type: module
 package: Testing
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 description: Testing module for the page header display event.


### PR DESCRIPTION
Fixes #246

Currently fails because we require drupal/linkit ^7.0 (latest recommended version) but this also needs to be bumped in localgov_page_components at the same time