### PR TITLE
style(standards): fix eslint js errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@fix/copy-core-prettier-config-before-testing
+    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@1.x
     with:
       project: 'localgovdrupal/localgov_core'
       project_path: 'web/modules/contrib/localgov_core'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@1.x
+    uses: localgovdrupal/localgov_shared_workflows/.github/workflows/test-module.yml@fix/copy-core-prettier-config-before-testing
     with:
       project: 'localgovdrupal/localgov_core'
       project_path: 'web/modules/contrib/localgov_core'

--- a/modules/localgov_admin_theme_improvements/js/gin-layout-paragraphs.js
+++ b/modules/localgov_admin_theme_improvements/js/gin-layout-paragraphs.js
@@ -1,42 +1,59 @@
 (function GinLayoutParagraphsScript(Drupal) {
   Drupal.behaviors.GinLayoutParagraphs = {
     attach(context) {
-
       function ginLayoutParagraphsFix() {
-        const layoutParagraphsDialogs = context.querySelectorAll('.ui-dialog.layout-paragraphs-dialog');
-        layoutParagraphsDialogs.forEach(layoutParagraphsDialog => {
+        const layoutParagraphsDialogs = context.querySelectorAll(
+          '.ui-dialog.layout-paragraphs-dialog',
+        );
+        layoutParagraphsDialogs.forEach((layoutParagraphsDialog) => {
           const form = layoutParagraphsDialog.closest('form');
           const overlay = context.querySelector('.ui-widget-overlay.ui-front');
-          const paragraphsField = layoutParagraphsDialog.closest('.field--type-entity-reference-revisions');
+          const paragraphsField = layoutParagraphsDialog.closest(
+            '.field--type-entity-reference-revisions',
+          );
           const placeholder = document.createElement('div');
-          placeholder.classList.add('js-layout-paragraph-base-field-placeholder');
+          placeholder.classList.add(
+            'js-layout-paragraph-base-field-placeholder',
+          );
 
-          if (layoutParagraphsDialog.classList.contains('js-localgov-layout-paragraph-processed')) {
-            return;
-          } else {
+          if (
+            !layoutParagraphsDialog.classList.contains(
+              'js-localgov-layout-paragraph-processed',
+            )
+          ) {
             if (!layoutParagraphsDialog.classList.contains('js-modal-moved')) {
               // Add a placeholder so the field can be moved back to here
               // when the modal is closed.
-              paragraphsField.insertBefore(placeholder, paragraphsField.querySelector('.form-item'));
-              
-              // Move the overlay and the paragraph entity reference field 
+              paragraphsField.insertBefore(
+                placeholder,
+                paragraphsField.querySelector('.form-item'),
+              );
+
+              // Move the overlay and the paragraph entity reference field
               // to be placed just before we close </form>.
-              form.insertBefore(overlay, context.querySelector('form > *:last-child').nextSibling);
-              form.insertBefore(paragraphsField, context.querySelector('form > *:last-child').nextSibling);
+              form.insertBefore(
+                overlay,
+                context.querySelector('form > *:last-child').nextSibling,
+              );
+              form.insertBefore(
+                paragraphsField,
+                context.querySelector('form > *:last-child').nextSibling,
+              );
               layoutParagraphsDialog.classList.add('js-modal-moved');
-                  
+
               // When modal is removed, move the paragraph entity reference field back.
-              layoutParagraphsDialog.addEventListener('remove', function() {
+              layoutParagraphsDialog.addEventListener('remove', () => {
                 placeholder.replaceWith(paragraphsField);
               });
             }
-            layoutParagraphsDialog.classList.add('js-localgov-layout-paragraph-processed')
+            layoutParagraphsDialog.classList.add(
+              'js-localgov-layout-paragraph-processed',
+            );
           }
-        })
+        });
       }
 
       ginLayoutParagraphsFix();
-
-    }
+    },
   };
 })(Drupal);


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Updates the JS to match Drupal Core eslint js standards

~Do not merge yet as eslint is not seeing the core prettier config so thinks `'` need replacing with `"` which is incorrect as the core prettier config has `"singleQuote": true,`~ see https://github.com/localgovdrupal/localgov_shared_workflows/pull/21 on failure