### PR TITLE
Fix NULL $extender breaks PageHeaderBlock

### DIFF
--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -18,6 +18,7 @@ use Drupal\views\Views;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Drupal\localgov_core\Plugin\views\display_extender\PageHeaderDisplayExtender;
 
 /**
  * Provides a 'PageHeaderBlock' block.
@@ -260,14 +261,18 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
     if ($this->view instanceof ViewExecutable) {
       $extender = $this->view->getDisplay()->getExtenders()['localgov_page_header_display_extender'] ?? NULL;
 
-      // Need to render view to apply tokens.
-      $this->view->render();
-      $lede = $extender->getLede();
-      return [
-        '#type' => 'html_tag',
-        '#tag' => 'p',
-        '#value' => $lede,
-      ];
+      // Only return a view lede if the Page Header Display extender is found.
+      if ($extender instanceof PageHeaderDisplayExtender) {
+
+        // Need to render view to apply tokens.
+        $this->view->render();
+        $lede = $extender->getLede();
+        return [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $lede,
+        ];
+      }
     }
 
     return NULL;

--- a/tests/src/Functional/ViewsPageExtenderTest.php
+++ b/tests/src/Functional/ViewsPageExtenderTest.php
@@ -6,6 +6,7 @@ use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\taxonomy\Traits\TaxonomyTestTrait;
 use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Functional tests for LocalGovDrupal install profile.
@@ -38,7 +39,7 @@ class ViewsPageExtenderTest extends BrowserTestBase {
   }
 
   /**
-   * Test block display.
+   * Test view with the page header extender displays correctly.
    */
   public function testViewWithPageHeadeExtender(): void {
 
@@ -65,6 +66,28 @@ class ViewsPageExtenderTest extends BrowserTestBase {
     $this->drupalGet('/oldest-content');
     $this->assertSession()->pageTextContains('The oldest 10 pages that have been created on ' . $site_name . ', including ' . $first_node->getTitle());
 
+  }
+
+  /**
+   * Test a view page displays even when the display extender is disabled.
+   */
+  public function testViewWithoutPageExtenderInstalled(): void {
+
+    // Disable the pageHeaderExtender.
+    $config = \Drupal::service('config.factory')->getEditable('views.settings');
+    $display_extenders = $config->get('display_extenders') ?: [];
+    $display_extenders = array_filter($display_extenders, function ($item) {
+      return $item != 'localgov_page_header_display_extender' ? TRUE : FALSE;
+    });
+    $config->set('display_extenders', $display_extenders);
+    $config->save();
+
+    // Try to access the test view.
+    $this->drupalGet('/recent-content');
+
+    // Test view page should still display without the extender enabled.
+    // @See https://github.com/localgovdrupal/localgov_core/issues/270
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
   }
 
 }


### PR DESCRIPTION
Fix #270.

Since the PageHeaderDisplay extender can be disabled, support cases when it is not enabled.

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

- Amend viewsPageExtenderTest to account for page header extender being disabled
- Fix pageHeaderBlock to account for when views page header display extender is disabled

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Under /admin/structure/views/settings/advanced turn off Page header display extender.
Then load a views page (or create a new page view).
Should no longer WSOD.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Less WSOD reports

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

Fallback is to NULL so restores previous behaviour.

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

n/a

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

n/a
