### PR TITLE
Remove patch for paragraphs module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,6 @@
             "drupal/field_group": {
                 "Nullable types #3490746": "https://git.drupalcode.org/project/field_group/-/commit/23540687517e3afee192f08f1c32a40d69f2dfa7.patch"
             },
-            "drupal/paragraphs": {
-                "Nullable types #3492419": "https://git.drupalcode.org/project/paragraphs/-/commit/9efaadd62448fc847f9860a2066d81c3039daa07.patch"
-            },
             "drupal/role_delegation": {
                 "Nullable types #3499682": "https://git.drupalcode.org/project/role_delegation/-/commit/f21be7a1f66de4a095c1398d9a53aa44bdad3524.patch"
             }


### PR DESCRIPTION
Latest composer update shows that this patch in composer.json for 3492419 no longer applies. 

Investigation shows the issue is fixed and released in https://www.drupal.org/project/paragraphs/releases/8.x-1.19 

Patch duly removed here. Not personally tested it, but here's the work.