### PR TITLE
feat: allow image_widget_crop 3 for D11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/field_group": "^3.1",
-        "drupal/image_widget_crop": "^2.3",
+        "drupal/image_widget_crop": "^2.3 || ^3.0",
         "drupal/linkit": "^6.1 || ^7.0",
         "drupal/media_library_edit": "^3.0",
         "drupal/metatag": "^2.0.2",


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This allows image_widget_crop 3 so we can have D11 compatibility as well as the existing version 2

Version 3
```
Works with Drupal: ^9.5 || ^10 || ^11
```

Version 2
```
Works with Drupal: ^8 || ^9 || ^10
```

Users can choose to fix to version 2 if they are on D10, however we can discuss next MT if we want to go straight to version 3.