### PR TITLE
fix: return type hint spacing

### DIFF
--- a/src/Event/PageHeaderDisplayEvent.php
+++ b/src/Event/PageHeaderDisplayEvent.php
@@ -78,7 +78,7 @@ class PageHeaderDisplayEvent extends Event {
    * @return \Drupal\Core\Entity\EntityInterface|null
    *   The entity.
    */
-  public function getEntity() : ?EntityInterface {
+  public function getEntity(): ?EntityInterface {
     return $this->entity;
   }
 
@@ -88,7 +88,7 @@ class PageHeaderDisplayEvent extends Event {
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity.
    */
-  public function setEntity(EntityInterface $entity) : void {
+  public function setEntity(EntityInterface $entity): void {
     $this->entity = $entity;
   }
 
@@ -98,7 +98,7 @@ class PageHeaderDisplayEvent extends Event {
    * @return \Drupal\views\ViewExecutable|null
    *   The view.
    */
-  public function getView() : ?ViewExecutable {
+  public function getView(): ?ViewExecutable {
     return $this->view;
   }
 
@@ -108,7 +108,7 @@ class PageHeaderDisplayEvent extends Event {
    * @param \Drupal\views\ViewExecutable $view
    *   The view.
    */
-  public function setView(ViewExecutable $view) : void {
+  public function setView(ViewExecutable $view): void {
     $this->view = $view;
   }
 

--- a/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
+++ b/src/Plugin/views/display_extender/PageHeaderDisplayExtender.php
@@ -168,7 +168,7 @@ class PageHeaderDisplayExtender extends DisplayExtenderPluginBase {
    * @return string
    *   Lede for display.
    */
-  public function getLede(bool $raw = FALSE) : string {
+  public function getLede(bool $raw = FALSE): string {
     $view = $this->view;
     $lede = '';
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes spacing issues with the return type hint. Getting ahead of these now before the Drupal coding standards change is implemented to check for this.