### PR TITLE
Add character counting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "drupal/metatag": "^2.0.2",
         "drupal/pathauto": "^1.8",
         "drupal/role_delegation": "^1.1",
+        "drupal/textfield_counter": "^2.4",
         "drupal/token": "^1.7"
     },
     "require-dev": {

--- a/modules/localgov_char_count/README.md
+++ b/modules/localgov_char_count/README.md
@@ -1,0 +1,1 @@
+##  LocalGov Character Count module

--- a/modules/localgov_char_count/config/install/localgov_char_count.settings.yml
+++ b/modules/localgov_char_count/config/install/localgov_char_count.settings.yml
@@ -1,3 +1,3 @@
 title_length: 60
 summary_length: 160
-status_message: '@current_length / @maxlength characters'
+status_message: '<span class="current_count">@current_length</span> / <span class="maxlength_count">@maxlength</span> characters'

--- a/modules/localgov_char_count/config/install/localgov_char_count.settings.yml
+++ b/modules/localgov_char_count/config/install/localgov_char_count.settings.yml
@@ -1,0 +1,3 @@
+title_length: 60
+summary_length: 160
+status_message: '@current_length / @maxlength characters'

--- a/modules/localgov_char_count/config/schema/localgov_char_count.schema.yml
+++ b/modules/localgov_char_count/config/schema/localgov_char_count.schema.yml
@@ -1,5 +1,5 @@
 localgov_char_count.settings:
-  type: mapping
+  type: config_object
   label: 'LocalGov character counting settings'
   mapping:
     title_length:

--- a/modules/localgov_char_count/config/schema/localgov_char_count.schema.yml
+++ b/modules/localgov_char_count/config/schema/localgov_char_count.schema.yml
@@ -1,0 +1,13 @@
+localgov_char_count.settings:
+  type: mapping
+  label: 'LocalGov character counting settings'
+  mapping:
+    title_length:
+      type: integer
+      label: 'The maximum number of characters allowed in the title field.'
+    summary_length:
+      type: integer
+      label: 'The maximum number of characters allowed in the title field.'
+    status_message:
+      type: string
+      label: 'The message shown indicating the status of the character count. The variables @maxlength, @current_length, @remaining_count'

--- a/modules/localgov_char_count/localgov_char_count.info.yml
+++ b/modules/localgov_char_count/localgov_char_count.info.yml
@@ -1,0 +1,8 @@
+name: 'LocalGov Character Count'
+type: module
+description: 'Adds character counting to text fields'
+package: LocalGov Drupal
+core_version_requirement: ^10 || ^11
+dependencies:
+  - textfield_counter:textfield_counter
+configure: localgov_char_count.character_counter_settings

--- a/modules/localgov_char_count/localgov_char_count.install
+++ b/modules/localgov_char_count/localgov_char_count.install
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the LocalGov Character Counter module.
+ */

--- a/modules/localgov_char_count/localgov_char_count.install
+++ b/modules/localgov_char_count/localgov_char_count.install
@@ -2,5 +2,5 @@
 
 /**
  * @file
- * Install, update and uninstall functions for the LocalGov Character Counter module.
+ * Install, update and uninstall functions for the LocalGov Character Counter.
  */

--- a/modules/localgov_char_count/localgov_char_count.links.menu.yml
+++ b/modules/localgov_char_count/localgov_char_count.links.menu.yml
@@ -1,0 +1,5 @@
+localgov_char_count.character_counter_settings:
+  title: LocalGov character counter
+  description: Enable/disable character counting.
+  parent: system.admin_config_content
+  route_name: localgov_char_count.character_counter_config

--- a/modules/localgov_char_count/localgov_char_count.links.menu.yml
+++ b/modules/localgov_char_count/localgov_char_count.links.menu.yml
@@ -2,4 +2,4 @@ localgov_char_count.character_counter_settings:
   title: LocalGov character counter
   description: Enable/disable character counting.
   parent: system.admin_config_content
-  route_name: localgov_char_count.character_counter_config
+  route_name: localgov_char_count.character_counter_settings

--- a/modules/localgov_char_count/localgov_char_count.module
+++ b/modules/localgov_char_count/localgov_char_count.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for LocalGov Character Counter module.
+ */

--- a/modules/localgov_char_count/localgov_char_count.permissions.yml
+++ b/modules/localgov_char_count/localgov_char_count.permissions.yml
@@ -1,0 +1,3 @@
+localgov character counting admin:
+  title: 'Administer LocalGov character counting'
+  description: 'Add and remove character counting for content types'

--- a/modules/localgov_char_count/localgov_char_count.routing.yml
+++ b/modules/localgov_char_count/localgov_char_count.routing.yml
@@ -1,0 +1,7 @@
+localgov_char_count.character_counter_settings:
+  path: '/admin/config/content/localgov-char-count'
+  defaults:
+    _title: 'Enable/disable character counting'
+    _form: 'Drupal\localgov_char_count\Form\CharacterCounterSettingsForm'
+  requirements:
+    _permission: 'administer localgov character counting'

--- a/modules/localgov_char_count/localgov_char_count.routing.yml
+++ b/modules/localgov_char_count/localgov_char_count.routing.yml
@@ -4,4 +4,4 @@ localgov_char_count.character_counter_settings:
     _title: 'Enable/disable character counting'
     _form: 'Drupal\localgov_char_count\Form\CharacterCounterSettingsForm'
   requirements:
-    _permission: 'administer localgov character counting'
+    _permission: 'localgov character counting admin'

--- a/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
+++ b/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
@@ -278,7 +278,6 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
       'text_textfield' => TRUE,
       default => FALSE,
     };
-
   }
 
   /**

--- a/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
+++ b/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Drupal\localgov_char_count\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityDisplayRepository;
 use Drupal\Core\Entity\EntityFieldManager;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Field\WidgetPluginManager;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -31,11 +33,25 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
   const DEFAULT_SUMMARY_LENGTH = 160;
 
   /**
+   * Default status message.
+   *
+   * @var string
+   */
+  const DEFAULT_STATUS_MESSAGE = '<span class="current_count">@current_length</span> / <span class="maxlength_count">@maxlength</span> characters';
+
+  /**
    * Config settings.
    *
    * @var string
    */
   const SETTINGS = 'localgov_char_count.settings';
+
+  /**
+   * The Entity Display Repository.
+   *
+   * @var \Drupal\Core\Entity\EntityDisplayRepository
+   */
+  protected EntityDisplayRepository $entityDisplayRepository;
 
   /**
    * The Entity Field Manager.
@@ -52,27 +68,41 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
   protected EntityTypeManager $entityTypeManager;
 
   /**
+   * The Widget Plugin Manager.
+   *
+   * @var \Drupal\Core\Field\WidgetPluginManager
+   */
+  protected WidgetPluginManager $widgetPluginManager;
+
+  /**
    * Constructs a \Drupal\system\ConfigFormBase object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
+   * @param \Drupal\Core\Entity\EntityDisplayRepository $entity_display_repository
+   *   The entity display repository.
    * @param \Drupal\Core\Entity\EntityFieldManager $entity_field_manager
    *   The entity field manager.
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
-   *    The entity type manager.
+   *   The entity type manager.
+   * @param \Drupal\Core\Field\WidgetPluginManager $widget_plugin_manager
+   *   The widget plugin manager.
    * @param \Drupal\Core\Config\TypedConfigManagerInterface|null $typed_config_manager
    *   The typed config manager.
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
+    EntityDisplayRepository $entity_display_repository,
     EntityFieldManager $entity_field_manager,
     EntityTypeManager $entity_type_manager,
+    WidgetPluginManager $widget_plugin_manager,
     protected $typed_config_manager = NULL,
-
   ) {
     parent::__construct($config_factory, $typed_config_manager);
+    $this->entityDisplayRepository = $entity_display_repository;
     $this->entityFieldManager = $entity_field_manager;
     $this->entityTypeManager = $entity_type_manager;
+    $this->widgetPluginManager = $widget_plugin_manager;
   }
 
   /**
@@ -81,8 +111,10 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
+      $container->get('entity_display.repository'),
       $container->get('entity_field.manager'),
       $container->get('entity_type.manager'),
+      $container->get('plugin.manager.field.widget'),
       $container->get('config.typed')
     );
   }
@@ -158,7 +190,7 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
       '#type' => 'textarea',
       '#title' => $this->t('Status message'),
       '#description' => $this->t('Enter the message to show to users indicating the current status of the character count. The variables <strong>@maxlength</strong>, <strong>@current_length</strong> and <strong>@remaining_count</strong> can be used in this field. For the real-time counter to work, said variables must be wrapped in HTML span tags with their classes respectively set to <strong>maxlength_count</strong>, <strong>current_count</strong> and <strong>remaining_count</strong>.'),
-      '#default_value' => $config->get('status_message') ?? '@current_length / @maxlength characters',
+      '#default_value' => $config->get('status_message') ?? static::DEFAULT_STATUS_MESSAGE,
       '#required' => TRUE,
     ];
     $form['fields'] = [
@@ -168,11 +200,19 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
       '#open' => TRUE,
     ];
     foreach ($char_count_fields as $bundle => $fields) {
+      $default_value = [];
+      $form_display = $this->entityDisplayRepository->getFormDisplay('node', $bundle, 'default');
+      foreach ($fields as $field => $label) {
+        $component = $form_display->getComponent($field);
+        if ($component && $this->isTextCounterComponent($component)) {
+          $default_value[] = $field;
+        }
+      }
       $form['fields'][$bundle] = [
         '#type' => 'checkboxes',
         '#title' => $node_types[$bundle]->label(),
         '#options' => $fields,
-        '#default_value' => array_keys($fields),
+        '#default_value' => $default_value,
       ];
     }
 
@@ -180,13 +220,6 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
     $form['actions']['submit']['#value'] = $this->t('Apply configuration changes');
 
     return $form;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function validateForm(array &$form, FormStateInterface $form_state): void {
-    parent::validateForm($form, $form_state);
   }
 
   /**
@@ -203,18 +236,134 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
       ->set('status_message', $values['config']['status_message'])
       ->save();
 
-    // Determine what's changing.
-    $add = [];
-    $remove = [];
+    // Determine which field widgets are changing.
     foreach ($values['fields'] as $bundle => $fields) {
-      if ($fields) {
-        $add[$bundle] = $fields;
+      $form_display = $this->entityDisplayRepository->getFormDisplay('node', $bundle, 'default');
+      foreach ($fields as $field => $status) {
+        if ($component = $form_display->getComponent($field)) {
+
+          // Convert to text field counter.
+          if ($this->isTextComponent($component) && $status !== 0) {
+            $component = $this->convertToTextCounter($field, $component);
+            $form_display->setComponent($field, $component);
+            $form_display->save();
+          }
+
+          // Convert to text field.
+          if ($this->isTextCounterComponent($component) && $status === 0) {
+            $component = $this->convertToText($component);
+            $form_display->setComponent($field, $component);
+            $form_display->save();
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Is text field component?
+   *
+   * @param array $component
+   *   The component to check.
+   *
+   * @return bool
+   *   TRUE if the component is a text field component, FALSE otherwise.
+   */
+  protected function isTextComponent(array $component): bool {
+    return match ($component['type']) {
+      'string_textarea',
+      'string_textfield',
+      'text_textarea',
+      'text_textarea_with_summary',
+      'text_textfield' => TRUE,
+      default => FALSE,
+    };
+
+  }
+
+  /**
+   * Is text field counter component?
+   *
+   * @param array $component
+   *   The component to check.
+   *
+   * @return bool
+   *   TRUE if the component is a text field counter component, FALSE otherwise.
+   */
+  protected function isTextCounterComponent(array $component): bool {
+    return match ($component['type']) {
+      'string_textarea_with_counter',
+      'string_textfield_with_counter',
+      'text_textarea_with_counter',
+      'text_textarea_with_summary_and_counter',
+      'text_textfield_with_counter' => TRUE,
+      default => FALSE,
+    };
+  }
+
+  /**
+   * Convert text field counter component config to text field.
+   *
+   * @param array $component
+   *   The component to convert.
+   *
+   * @return array
+   *   The converted component.
+   */
+  protected function convertToText(array $component): array {
+
+    if ($component['type'] === 'text_textarea_with_summary_and_counter') {
+      $component['type'] = 'text_textarea_with_summary';
+      $field_settings = $this->widgetPluginManager->getDefaultSettings($component['type']);
+      $field_settings['show_summary'] = TRUE;
+    }
+    else {
+      $component['type'] = str_replace('_with_counter', '', $component['type']);
+      $field_settings = $this->widgetPluginManager->getDefaultSettings($component['type']);
+    }
+    $component['settings'] = $field_settings;
+
+    return $component;
+  }
+
+  /**
+   * Convert text field component config to text counter field.
+   *
+   * @param string $field
+   *   Name of field to convert.
+   * @param array $component
+   *   The component to convert.
+   *
+   * @return array
+   *   The converted component.
+   */
+  protected function convertToTextCounter(string $field, array $component): array {
+    $config = $this->config(static::SETTINGS);
+
+    if ($component['type'] === 'text_textarea_with_summary') {
+      $component['type'] = 'text_textarea_with_summary_and_counter';
+      $field_settings = $this->widgetPluginManager->getDefaultSettings($component['type']);
+      $field_settings['summary_maxlength'] = $config->get('summary_length');
+      $field_settings['show_summary'] = TRUE;
+    }
+    else {
+      $component['type'] .= '_with_counter';
+      $field_settings = $this->widgetPluginManager->getDefaultSettings($component['type']);
+      if ($field === 'title') {
+        $field_settings['maxlength'] = $config->get('title_length');
       }
       else {
-        $remove[$bundle] = $fields;
+        $field_settings['maxlength'] = $config->get('summary_length');
       }
     }
 
-    $x=0;
+    $field_settings['count_html_characters'] = FALSE;
+    $field_settings['count_only_mode'] = TRUE;
+    $field_settings['js_prevent_submit'] = FALSE;
+    $field_settings['textcount_status_message'] = $config->get('status_message');
+    $component['settings'] = $field_settings;
+
+    return $component;
   }
+
 }

--- a/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
+++ b/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\localgov_char_count\Form;
 
-use Drupal\Core\Form\FormBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityFieldManager;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a LocalGov Character Counter form.
  */
-class CharacterCounterSettingsForm extends FormBase {
+class CharacterCounterSettingsForm extends ConfigFormBase {
 
   /**
    * Default title length.
@@ -34,6 +38,56 @@ class CharacterCounterSettingsForm extends FormBase {
   const SETTINGS = 'localgov_char_count.settings';
 
   /**
+   * The Entity Field Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManager
+   */
+  protected EntityFieldManager $entityFieldManager;
+
+  /**
+   * The Entity Type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected EntityTypeManager $entityTypeManager;
+
+  /**
+   * Constructs a \Drupal\system\ConfigFormBase object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Entity\EntityFieldManager $entity_field_manager
+   *   The entity field manager.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   *    The entity type manager.
+   * @param \Drupal\Core\Config\TypedConfigManagerInterface|null $typed_config_manager
+   *   The typed config manager.
+   */
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    EntityFieldManager $entity_field_manager,
+    EntityTypeManager $entity_type_manager,
+    protected $typed_config_manager = NULL,
+
+  ) {
+    parent::__construct($config_factory, $typed_config_manager);
+    $this->entityFieldManager = $entity_field_manager;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_field.manager'),
+      $container->get('entity_type.manager'),
+      $container->get('config.typed')
+    );
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function getFormId(): string {
@@ -43,10 +97,14 @@ class CharacterCounterSettingsForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state): array {
-    $entity_type_manager = \Drupal::service('entity_type.manager');
-    $field_manager = \Drupal::service('entity_field.manager');
+  protected function getEditableConfigNames(): array {
+    return [static::SETTINGS];
+  }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config(static::SETTINGS);
 
     // Determine which fields to apply character counting to.
@@ -56,8 +114,8 @@ class CharacterCounterSettingsForm extends FormBase {
       'localgov_subsites_summary' => 'Subsites summary',
     ];
     $char_count_fields = [];
-    $node_types = $entity_type_manager->getStorage('node_type')->loadMultiple();
-    $field_map = $field_manager->getFieldMap();
+    $node_types = $this->entityTypeManager->getStorage('node_type')->loadMultiple();
+    $field_map = $this->entityFieldManager->getFieldMap();
     foreach ($char_count_field_names as $field_name => $label) {
       if (isset($field_map['node'][$field_name]['bundles'])) {
         foreach ($field_map['node'][$field_name]['bundles'] as $bundle) {
@@ -76,22 +134,32 @@ class CharacterCounterSettingsForm extends FormBase {
       '#type' => 'markup',
       '#markup' => $this->t('This form allows you to easily apply character counting to title and summary fields for LocalGov Drupal content types. If you need more control than this form allows, it\'s possible to configure each field individually. For further information, see the docs of the <a href="https://www.drupal.org/project/textfield_counter">Textfield Counter module</a>.'),
     ];
-    $form['lengths'] = [
+    $form['config'] = [
       '#type' => 'details',
-      '#title' => $this->t('Field lengths'),
-      '#description' => $this->t('Set the length to be applied to text fields.'),
+      '#title' => $this->t('Field configuration'),
       '#open' => TRUE,
 
     ];
-    $form['lengths']['title_length'] = [
+    $form['config']['title_length'] = [
       '#type' => 'number',
       '#title' => $this->t('Title length'),
+      '#description' => $this->t('The maximum number of characters allowed in the title field.'),
       '#default_value' => $config->get('title_length') ?? static::DEFAULT_TITLE_LENGTH,
+      '#required' => TRUE,
     ];
-    $form['lengths']['summary_length'] = [
+    $form['config']['summary_length'] = [
       '#type' => 'number',
       '#title' => $this->t('Summary length'),
+      '#description' => $this->t('The maximum number of characters allowed in the summary field.'),
       '#default_value' => $config->get('summary_length') ?? static::DEFAULT_SUMMARY_LENGTH,
+      '#required' => TRUE,
+    ];
+    $form['config']['status_message'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Status message'),
+      '#description' => $this->t('Enter the message to show to users indicating the current status of the character count. The variables <strong>@maxlength</strong>, <strong>@current_length</strong> and <strong>@remaining_count</strong> can be used in this field. For the real-time counter to work, said variables must be wrapped in HTML span tags with their classes respectively set to <strong>maxlength_count</strong>, <strong>current_count</strong> and <strong>remaining_count</strong>.'),
+      '#default_value' => $config->get('status_message') ?? '@current_length / @maxlength characters',
+      '#required' => TRUE,
     ];
     $form['fields'] = [
       '#type' => 'details',
@@ -107,10 +175,9 @@ class CharacterCounterSettingsForm extends FormBase {
         '#default_value' => array_keys($fields),
       ];
     }
-    $form['actions']['submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Apply'),
-    ];
+
+    $form = parent::buildForm($form, $form_state);
+    $form['actions']['submit']['#value'] = $this->t('Apply configuration changes');
 
     return $form;
   }
@@ -128,8 +195,26 @@ class CharacterCounterSettingsForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     $values = $form_state->getValues();
 
+    // Save settings.
+    $config = $this->config(static::SETTINGS);
+    $config
+      ->set('title_length', $values['config']['title_length'])
+      ->set('summary_length', $values['config']['summary_length'])
+      ->set('status_message', $values['config']['status_message'])
+      ->save();
+
+    // Determine what's changing.
+    $add = [];
+    $remove = [];
+    foreach ($values['fields'] as $bundle => $fields) {
+      if ($fields) {
+        $add[$bundle] = $fields;
+      }
+      else {
+        $remove[$bundle] = $fields;
+      }
+    }
 
     $x=0;
   }
-
 }

--- a/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
+++ b/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\localgov_char_count\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a LocalGov Character Counter form.
+ */
+class CharacterCounterSettingsForm extends FormBase {
+
+  /**
+   * Default title length.
+   *
+   * @var int
+   */
+  const DEFAULT_TITLE_LENGTH = 60;
+
+  /**
+   * Default summary length.
+   *
+   * @var int
+   */
+  const DEFAULT_SUMMARY_LENGTH = 160;
+
+  /**
+   * Config settings.
+   *
+   * @var string
+   */
+  const SETTINGS = 'localgov_char_count.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'localgov_char_count_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $entity_type_manager = \Drupal::service('entity_type.manager');
+    $field_manager = \Drupal::service('entity_field.manager');
+
+    $config = $this->config(static::SETTINGS);
+
+    // Determine which fields to apply character counting to.
+    $char_count_field_names = [
+      'title' => 'Title',
+      'body' => 'Summary',
+      'localgov_subsites_summary' => 'Subsites summary',
+    ];
+    $char_count_fields = [];
+    $node_types = $entity_type_manager->getStorage('node_type')->loadMultiple();
+    $field_map = $field_manager->getFieldMap();
+    foreach ($char_count_field_names as $field_name => $label) {
+      if (isset($field_map['node'][$field_name]['bundles'])) {
+        foreach ($field_map['node'][$field_name]['bundles'] as $bundle) {
+          if (str_starts_with($bundle, 'localgov_')) {
+            $char_count_fields[$bundle][$field_name] = $label;
+          }
+        }
+      }
+    }
+
+    // Build form.
+    $form = [
+      '#tree' => TRUE,
+    ];
+    $form['description'] = [
+      '#type' => 'markup',
+      '#markup' => $this->t('This form allows you to easily apply character counting to title and summary fields for LocalGov Drupal content types. If you need more control than this form allows, it\'s possible to configure each field individually. For further information, see the docs of the <a href="https://www.drupal.org/project/textfield_counter">Textfield Counter module</a>.'),
+    ];
+    $form['lengths'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Field lengths'),
+      '#description' => $this->t('Set the length to be applied to text fields.'),
+      '#open' => TRUE,
+
+    ];
+    $form['lengths']['title_length'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Title length'),
+      '#default_value' => $config->get('title_length') ?? static::DEFAULT_TITLE_LENGTH,
+    ];
+    $form['lengths']['summary_length'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Summary length'),
+      '#default_value' => $config->get('summary_length') ?? static::DEFAULT_SUMMARY_LENGTH,
+    ];
+    $form['fields'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Fields to apply character counting to.'),
+      '#description' => $this->t('Checked fields will have character counting added to them if it already set. Unchecked fields will remove character counting if already setup.'),
+      '#open' => TRUE,
+    ];
+    foreach ($char_count_fields as $bundle => $fields) {
+      $form['fields'][$bundle] = [
+        '#type' => 'checkboxes',
+        '#title' => $node_types[$bundle]->label(),
+        '#options' => $fields,
+        '#default_value' => array_keys($fields),
+      ];
+    }
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Apply'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $values = $form_state->getValues();
+
+
+    $x=0;
+  }
+
+}

--- a/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
+++ b/modules/localgov_char_count/src/Form/CharacterCounterSettingsForm.php
@@ -108,7 +108,7 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): self {
     return new static(
       $container->get('config.factory'),
       $container->get('entity_display.repository'),
@@ -196,7 +196,7 @@ class CharacterCounterSettingsForm extends ConfigFormBase {
     $form['fields'] = [
       '#type' => 'details',
       '#title' => $this->t('Fields to apply character counting to.'),
-      '#description' => $this->t('Checked fields will have character counting added to them if it already set. Unchecked fields will remove character counting if already setup.'),
+      '#description' => $this->t('Checking a field will add character counting to it if not already configured. Unchecking a field will remove character counting from it.'),
       '#open' => TRUE,
     ];
     foreach ($char_count_fields as $bundle => $fields) {

--- a/modules/localgov_char_count/tests/src/Functional/SettingsFormTest.php
+++ b/modules/localgov_char_count/tests/src/Functional/SettingsFormTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\Tests\localgov_char_count\FunctionalJavascript;
+
+use Drupal\Core\Url;
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\localgov_char_count\Form\CharacterCounterSettingsForm;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+
+/**
+ * Tests the character count settings form.
+ *
+ * @group localgov_char_count
+ */
+class SettingsFormTest extends WebDriverTestBase {
+
+  use ContentTypeCreationTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'node',
+    'localgov_char_count',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Create a LocalGov content type with title and body fields.
+    $this->createContentType([
+      'type' => 'localgov_page',
+      'title' => 'LocalGov Page',
+    ]);
+  }
+
+  /**
+   * Test settings form.
+   */
+  public function testSettingsForm(): void {
+    $admin_user = $this->drupalCreateUser([
+      'access administration pages',
+      'access content',
+      'administer nodes',
+      'administer site configuration',
+      'bypass node access',
+      'localgov character counting admin',
+    ]);
+    $this->drupalLogin($admin_user);
+
+    $title_counter_message = '0 / ' . CharacterCounterSettingsForm::DEFAULT_TITLE_LENGTH . ' characters';
+    $summary_counter_message = '0 / ' . CharacterCounterSettingsForm::DEFAULT_SUMMARY_LENGTH . ' characters';
+
+    // Enable character counting.
+    $this->drupalGet(Url::fromRoute('localgov_char_count.character_counter_settings'));
+    $this->getSession()->getPage()->hasUncheckedField('fields[localgov_page][title]');
+    $this->getSession()->getPage()->hasUncheckedField('fields[localgov_page][body]');
+    $this->getSession()->getPage()->checkField('fields[localgov_page][title]');
+    $this->getSession()->getPage()->checkField('fields[localgov_page][body]');
+    $this->getSession()->getPage()->pressButton('Apply configuration changes');
+    $this->assertSession()->addressEquals(Url::fromRoute('localgov_char_count.character_counter_settings'));
+    $this->getSession()->getPage()->hasCheckedField('fields[localgov_page][title]');
+    $this->getSession()->getPage()->hasCheckedField('fields[localgov_page][body]');
+
+    // Check node edit form does include character counter.
+    $this->drupalGet('/node/add/localgov_page');
+    $this->assertSession()->elementTextContains('css', '.form-item-title-0-value', $title_counter_message);
+    $this->assertSession()->elementTextContains('css', '.form-item-body-0-summary', $summary_counter_message);
+
+    // Disable character counting.
+    $this->drupalGet(Url::fromRoute('localgov_char_count.character_counter_settings'));
+    $this->getSession()->getPage()->uncheckField('fields[localgov_page][title]');
+    $this->getSession()->getPage()->uncheckField('fields[localgov_page][body]');
+    $this->getSession()->getPage()->pressButton('Apply configuration changes');
+
+    // Check node edit form doesn't include character counter.
+    $this->drupalGet('/node/add/localgov_page');
+    $this->assertSession()->elementTextNotContains('css', '.form-item-title-0-value', $title_counter_message);
+    $this->assertSession()->elementTextNotContains('css', '.form-item-body-0-summary', $summary_counter_message);
+  }
+  
+}

--- a/modules/localgov_char_count/tests/src/Functional/SettingsFormTest.php
+++ b/modules/localgov_char_count/tests/src/Functional/SettingsFormTest.php
@@ -88,5 +88,5 @@ class SettingsFormTest extends WebDriverTestBase {
     $this->assertSession()->elementTextNotContains('css', '.form-item-title-0-value', $title_counter_message);
     $this->assertSession()->elementTextNotContains('css', '.form-item-body-0-summary', $summary_counter_message);
   }
-  
+
 }


### PR DESCRIPTION
## What does this change?

Adds a UI to easily enable character counting on test fields.

## How to test

Checkout this branch and enable the localgov_char_count module. The settings form is at /admin/config/content/localgov-char-count which should allow you to turn on and off character counting for title and summary fields for LGD content types.
