### PR TITLE
Feature/2.x/194 add entity and bundle template suggestions to page header block

### DIFF
--- a/localgov_core.module
+++ b/localgov_core.module
@@ -31,9 +31,12 @@ function localgov_core_theme_suggestions_localgov_page_header_block(array $varia
   $suggestions = [];
   $entity = $variables['entity'];
 
-  $suggestions[] = 'localgov_page_header_block__' . $entity->bundle();
-  $suggestions[] = 'localgov_page_header_block__' . $entity->id();
-  $suggestions[] = 'localgov_page_header_block__' . $entity->getEntityTypeId();
+  if ($entity instanceof NodeInterface || $entity instanceof TermInterface) {
+    $suggestions[] = 'localgov_page_header_block__' . $entity->bundle();
+    $suggestions[] = 'localgov_page_header_block__' . $entity->id();
+    $suggestions[] = 'localgov_page_header_block__' . $entity->getEntityTypeId();
+  }
+
   return $suggestions;
 }
 

--- a/localgov_core.module
+++ b/localgov_core.module
@@ -17,6 +17,7 @@ function localgov_core_theme($existing, $type, $theme, $path) {
         'title' => '',
         'subtitle' => NULL,
         'lede' => NULL,
+        'entity' => NULL,
       ],
       'render element' => 'block',
     ],

--- a/localgov_core.module
+++ b/localgov_core.module
@@ -33,6 +33,7 @@ function localgov_core_theme_suggestions_localgov_page_header_block(array $varia
 
   $suggestions[] = 'localgov_page_header_block__' . $entity->bundle();
   $suggestions[] = 'localgov_page_header_block__' . $entity->id();
+  $suggestions[] = 'localgov_page_header_block__' . $entity->getEntityTypeId();
   return $suggestions;
 }
 

--- a/localgov_core.module
+++ b/localgov_core.module
@@ -34,9 +34,12 @@ function localgov_core_theme_suggestions_localgov_page_header_block(array $varia
   $entity = $variables['entity'];
 
   if ($entity instanceof NodeInterface || $entity instanceof TermInterface) {
-    $suggestions[] = 'localgov_page_header_block__' . $entity->bundle();
-    $suggestions[] = 'localgov_page_header_block__' . $entity->id();
-    $suggestions[] = 'localgov_page_header_block__' . $entity->getEntityTypeId();
+    $id = $entity->id();
+    $type = $entity->getEntityTypeId();
+    $bundle = $entity->bundle();
+    $suggestions[] = 'localgov_page_header_block__' . $bundle;
+    $suggestions[] = 'localgov_page_header_block__' . $type . '__' . $id;
+    $suggestions[] = 'localgov_page_header_block__' . $type;
   }
 
   return $suggestions;

--- a/localgov_core.module
+++ b/localgov_core.module
@@ -27,7 +27,7 @@ function localgov_core_theme($existing, $type, $theme, $path) {
 /**
  * Implements hook_theme_suggestions_HOOK().
  */
-function localgov_core_theme_suggestions_localgov_page_header_block(array $variables) {
+function localgov_core_theme_suggestions_localgov_page_header_block(array $variables): array {
   $suggestions = [];
   $entity = $variables['entity'];
 

--- a/localgov_core.module
+++ b/localgov_core.module
@@ -25,6 +25,18 @@ function localgov_core_theme($existing, $type, $theme, $path) {
 }
 
 /**
+ * Implements hook_theme_suggestions_HOOK().
+ */
+function localgov_core_theme_suggestions_localgov_page_header_block(array $variables) {
+  $suggestions = [];
+  $entity = $variables['entity'];
+
+  $suggestions[] = 'localgov_page_header_block__' . $entity->bundle();
+  $suggestions[] = 'localgov_page_header_block__' . $entity->id();
+  return $suggestions;
+}
+
+/**
  * Implements hook_template_preprocess_default_variables_alter().
  */
 function localgov_core_template_preprocess_default_variables_alter(&$variables) {

--- a/localgov_core.module
+++ b/localgov_core.module
@@ -1,14 +1,13 @@
 <?php
 
-use Drupal\node\NodeInterface;
-use Drupal\taxonomy\TermInterface;
-
 /**
  * @file
  * LocalGovDrupal Core module file.
  */
 
 use Drupal\Core\Installer\InstallerKernel;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Implements hook_theme().

--- a/localgov_core.module
+++ b/localgov_core.module
@@ -1,5 +1,8 @@
 <?php
 
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+
 /**
  * @file
  * LocalGovDrupal Core module file.

--- a/src/Plugin/Block/PageHeaderBlock.php
+++ b/src/Plugin/Block/PageHeaderBlock.php
@@ -211,6 +211,7 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
       '#title' => $this->title,
       '#subtitle' => $this->subTitle,
       '#lede' => $this->lede,
+      '#entity' => $this->entity,
     ];
 
     return $build;


### PR DESCRIPTION
Re: https://github.com/localgovdrupal/localgov_core/issues/194

## What does this change?

This makes three non-breaking changes to `localgov_core`'s Page Header Block:

1. adds `#entity` to `localgov_page_header_block` in `localgov_core_theme()`
2. adds the current entity to `PageHeaderBlock.php`.s render array
3. adds Twig template suggestions to the block via `localgov_core_theme_suggestions_localgov_page_header_block()`

## How to test

There are five things requiring testing:

1. that _nothing changes_ on existing sites like https://demo.localgovdrupal.org
2. that three types of Twig template suggestions are provided:
  - per entity id, e.g. `localgov-page-header-block--node--7.html.twig`
  - per bundle, e.g. `localgov-page-header-block--localgov-services-landing.html.twig`
  - per entity type, e.g. `localgov-page-header-block--node.html.twig`
  
    ![image](https://github.com/user-attachments/assets/918bbe28-99f7-49e5-b0ad-bf1c075d6df9)
3. that the expected entity is present in Twig; add the following to `localgov-page-header-block.html.twig` (or one of the suggested ones) and verify on the front end:
    ```twig
    {#
      On e.g. a localgov_services_landing node, with nid 7, this should produce the following output:
      
    0 array:3 [
      0 => "7"
      1 => "localgov_services_landing"
      2 => "node"
    ]
    
    #}
    {{ dump([
      entity.id(),
      entity.bundle(),
      entity.getEntityTypeId(),
    ]) }}
    ```
4. that templates named according to the suggestions are discovered and rendered
5. that non-entity pages (like Views) don't break because of these changes

## How can we measure success?

Three ways:

1. if nothing whatever changes on any existing site
2. that it becomes possible to access the base entity from within the block template
3. that it becomes possible to override the module's template (and `localgov_base`'s template) with nid, bundle, and entity type specific templates.

## Have we considered potential risks?

As this is only intended to expand what's _possible_ without actually changing anything, it should be low risk (mainly the risk is that I've failed to grasp something important in the block plugin :smiley:)

## Images

n/a

## Accessibility

n/a