### PR TITLE
CSS/JS from localgov_base is not removed if it comes from an SDC component

### DIFF
--- a/localgov_core.module
+++ b/localgov_core.module
@@ -24,6 +24,27 @@ function localgov_core_theme($existing, $type, $theme, $path) {
 }
 
 /**
+ * Implements hook_library_info_alter().
+ */
+function localgov_core_library_info_alter(&$libraries, $extension) {
+  if ($extension === 'core') {
+    $remove_css = (bool) theme_get_setting('localgov_base_remove_css');
+    $remove_js = (bool) theme_get_setting('localgov_base_remove_js');
+
+    foreach($libraries as $name => $library) {
+      if (str_starts_with($name, 'components.localgov_base--')) {
+        if ($remove_css) {
+          $libraries[$name]['css'] = [];
+        }
+        if ($remove_js) {
+          $libraries[$name]['js'] = [];
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_template_preprocess_default_variables_alter().
  */
 function localgov_core_template_preprocess_default_variables_alter(&$variables) {


### PR DESCRIPTION
Fixes #280


## What does this change?

See #280 for the discussion.

## How to test

1. Add the `localgov_base:add-to-calendar.twig` component to an existing Drupal template. (For some reason I can't find any templates in LocalGov that are using the localgov_base components yet.)
2. Notice that the `add-to-calandar.css` and `add-to-calandar.js` files are added to the webpage when the component is used.
3. Turn on the "localgov_base_remove_css" and "localgov_base_remove_js" theme settings in your theme.
4. Notice that the `add-to-calandar.css` and `add-to-calandar.js` files are STILL added to the webpage when the component is used.

## How can we measure success?

1. Apply the patch and retest with different combos of on/off for those theme settings. SDC creates a single library with both the CSS and the JS in it, but the new hook removes just the CSS or just the JS if that's what the theme settings are set to.
