### PR TITLE
With the view "files" disabled, localgov_core cause an exception

### DIFF
--- a/localgov_core.links.task.yml
+++ b/localgov_core.links.task.yml
@@ -1,5 +1,3 @@
 localgov_core.files:
-  title: 'Files'
-  parent_id: entity.media.collection
-  route_name: view.files.page_1
+  deriver: 'Drupal\localgov_core\Plugin\Derivative\FilesLocalTasks'
   weight: 100

--- a/src/Plugin/Derivative/FilesLocalTasks.php
+++ b/src/Plugin/Derivative/FilesLocalTasks.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\localgov_core\Plugin\Derivative;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Routing\RouteProviderInterface;
+use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides local task for files view under entity media collection.
+ */
+class FilesLocalTasks extends DeriverBase implements ContainerDeriverInterface {
+
+  /**
+   * The route provider.
+   *
+   * @var \Drupal\Core\Routing\RouteProviderInterface
+   */
+  protected $routeProvider;
+
+  /**
+   * Constructs a \Drupal\localgov_core\Plugin\Derivative\FilesLocalTasks instance.
+   *
+   * @param \Drupal\Core\Routing\RouteProviderInterface $route_provider
+   *   The route provider.
+   */
+  public function __construct(RouteProviderInterface $route_provider) {
+    $this->routeProvider = $route_provider;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, $base_plugin_id) {
+    return new static(
+      $container->get('router.route_provider'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition) {
+
+    try {
+      if ($this->routeProvider->getRouteByName('view.files.page_1')) {
+        $this->derivatives['localgov_core.files'] = $base_plugin_definition;
+        $this->derivatives['localgov_core.files']['parent_id'] = 'entity.media.collection';
+        $this->derivatives['localgov_core.files']['title'] = 'Files';
+        $this->derivatives['localgov_core.files']['route_name'] = 'view.files.page_1';
+      }
+    }
+    catch (\Exception $exception) {
+      // Throw $th;.
+    }
+    return parent::getDerivativeDefinitions($base_plugin_definition);
+  }
+
+}

--- a/src/Plugin/Derivative/FilesLocalTasks.php
+++ b/src/Plugin/Derivative/FilesLocalTasks.php
@@ -52,7 +52,9 @@ class FilesLocalTasks extends DeriverBase implements ContainerDeriverInterface {
       }
     }
     catch (\Exception $exception) {
-      // Throw $th;.
+      // Nothing to log here.
+      // getRouteByName throw an exception If a matching route cannot be found.
+      // However, if the route do not exists, it is not an error in this case.
     }
     return parent::getDerivativeDefinitions($base_plugin_definition);
   }


### PR DESCRIPTION
## What does this change?
Fixes #282

## How to test

1.  Disable the view files
2.  Open the path admin/content/media
3.  Notice that the page is loaded properly without error and the tab files is not available
4.  Re-enable the view files
5.  Open the path admin/content/media
3.  Notice that the page is loaded properly and the tab files is now available

## How can we measure success?
The media view is accessible even when the files view is not available