### PR TITLE
feat: upgrade field_group to version 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,6 @@
             "drupal/core": "-p2"
         },
         "patches": {
-            "drupal/field_group": {
-                "Nullable types #3490746": "https://git.drupalcode.org/project/field_group/-/commit/23540687517e3afee192f08f1c32a40d69f2dfa7.patch"
-            },
             "drupal/role_delegation": {
                 "Nullable types #3499682": "https://git.drupalcode.org/project/role_delegation/-/commit/f21be7a1f66de4a095c1398d9a53aa44bdad3524.patch"
             }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "drupal/field_group": "^3.1",
+        "drupal/field_group": "^4.0",
         "drupal/image_widget_crop": "^2.3 || ^3.0",
         "drupal/linkit": "^6.1 || ^7.0",
         "drupal/media_library_edit": "^3.0",


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This upgrades field_group to v4, this brings UX bug fixes and some general bug fixes.

The maintainer says this about v4;

> Switching to SemVer. Besides that, 4.0.0 is just a bugfix and feature release of 8.x-3.x.

So should be safe to bump the version.

field_group v3 is due to be marked as unsupported soon see https://www.drupal.org/project/field_group/issues/3520770#comment-16083966

## How to test

Testing will mean also updating to the following modules which also have PRs for field_group v4

- localgov_core
- localgov_services
- localgov_paragraphs
- localgov_news