### PR TITLE
Update filter orders so image alignment works

### DIFF
--- a/modules/localgov_media/config/optional/filter.format.wysiwyg.yml
+++ b/modules/localgov_media/config/optional/filter.format.wysiwyg.yml
@@ -9,7 +9,6 @@ dependencies:
   module:
     - editor
     - linkit
-    - localgov_publications
     - media
 name: WYSIWYG
 format: wysiwyg

--- a/modules/localgov_media/config/optional/filter.format.wysiwyg.yml
+++ b/modules/localgov_media/config/optional/filter.format.wysiwyg.yml
@@ -9,6 +9,7 @@ dependencies:
   module:
     - editor
     - linkit
+    - localgov_publications
     - media
 name: WYSIWYG
 format: wysiwyg
@@ -18,58 +19,64 @@ filters:
     id: editor_file_reference
     provider: editor
     status: true
-    weight: -44
+    weight: -45
     settings: {  }
   filter_align:
     id: filter_align
     provider: filter
     status: true
-    weight: -49
+    weight: -47
     settings: {  }
   filter_autop:
     id: filter_autop
     provider: filter
     status: true
-    weight: -43
+    weight: -44
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: false
-    weight: -42
+    weight: -41
     settings: {  }
   filter_html:
     id: filter_html
     provider: filter
     status: true
-    weight: -47
+    weight: -48
     settings:
-      allowed_html: '<br> <code> <pre> <p class="alert alert-info alert-danger alert-fail alert-success callout callout-primary callout-success callout-danger callout-teal callout-carbon callout-yellow"> <h1> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <a class="external-link pdf-link btn btn-start" hreflang title href data-entity-type data-entity-uuid data-entity-substitution> <ul class="list-checked" type> <cite> <dl> <dt> <dd> <mark> <blockquote cite> <ol type start> <img data-entity-type data-entity-uuid data-caption src alt height width data-align> <drupal-media data-caption title data-entity-type data-entity-uuid alt data-view-mode data-align> <span dir> <strong> <em> <u> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption>'
+      allowed_html: '<br> <p class="alert alert-info alert-danger alert-fail alert-success callout callout-primary callout-success callout-danger callout-teal callout-carbon callout-yellow"> <h1> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <a class="external-link pdf-link btn btn-start" hreflang title href data-entity-type data-entity-uuid data-entity-substitution> <ul class="list-checked" type> <cite> <dl> <dt> <dd> <mark> <blockquote cite> <ol type start> <img data-entity-type data-entity-uuid data-caption src alt height width data-align> <drupal-media data-caption title data-entity-type data-entity-uuid alt data-view-mode data-align> <span dir> <strong> <em> <u> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
-    weight: -45
+    weight: -42
     settings: {  }
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -40
+    weight: -39
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: true
-    weight: -48
+    weight: -49
+    settings: {  }
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: false
+    weight: -38
     settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: false
-    weight: -41
+    weight: -40
     settings:
       filter_url_length: 72
   linkit:


### PR DESCRIPTION
Closes #272 

## What does this change?

Moves the 'Align Images' filter to below "Correct HTML" so that text can wrap around images.

