### PR TITLE
Add a dependency on core to media view

### DIFF
--- a/modules/localgov_media/config/optional/views.view.media.yml
+++ b/modules/localgov_media/config/optional/views.view.media.yml
@@ -6,6 +6,7 @@ dependencies:
   module:
     - entity_usage
     - image
+    - localgov_core
     - media
     - user
 id: media

--- a/modules/localgov_media/localgov_media.info.yml
+++ b/modules/localgov_media/localgov_media.info.yml
@@ -12,3 +12,4 @@ dependencies:
   - drupal:responsive_image
   - image_widget_crop:image_widget_crop
   - linkit:linkit
+  - localgov_core:localgov_core

--- a/modules/localgov_media/localgov_media.info.yml
+++ b/modules/localgov_media/localgov_media.info.yml
@@ -12,4 +12,3 @@ dependencies:
   - drupal:responsive_image
   - image_widget_crop:image_widget_crop
   - linkit:linkit
-  - localgov_core:localgov_core


### PR DESCRIPTION
Fixes #302 

## What does this change?

~~Adds a dependency on localgov_core to localgov_media. See #302 for an alternative approach.~~

Adds a dependency on localgov_core to media view in localgov_media.

## How to test

The testLocalGovDrupalProfile PHPUnit test in the profile passes.

## Have we considered potential risks?

~~Is there a possibility that anyone is using localgov_media without localgov_core?~~
