### PR TITLE
Media module container_rebuild_required key for D11.2

### DIFF
--- a/modules/localgov_media/localgov_media.info.yml
+++ b/modules/localgov_media/localgov_media.info.yml
@@ -3,6 +3,7 @@ description: LocalGov Media configuration.
 package: LocalGov Drupal
 type: module
 core_version_requirement: ^10 || ^11
+container_rebuild_required: true
 
 dependencies:
   - drupal:ckeditor5


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes https://github.com/localgovdrupal/localgov_core/issues/307
Introduces container_rebuild_required key for the media module for 11.2+ support

## How to test

- Tests should no longer complain about the media config, e.g. https://github.com/localgovdrupal/localgov_paragraphs/issues/247 

- The project should install on 11.2
- Should not be regressions when installing for older versions of Drupal

## How can we measure success?

We can move closer to Drupal 11.2 support. 

## Have we considered potential risks?

The key breaks something in older versions
We enter a game of 'whack-a-mole' where we move on just one step and see another failure. 