### PR TITLE
fix: add container_rebuild_required true to support installing on Drupal 11.2

### DIFF
--- a/modules/localgov_media/localgov_media.info.yml
+++ b/modules/localgov_media/localgov_media.info.yml
@@ -3,6 +3,7 @@ description: LocalGov Media configuration.
 package: LocalGov Drupal
 type: module
 core_version_requirement: ^10 || ^11
+container_rebuild_required: true
 
 dependencies:
   - drupal:ckeditor5


### PR DESCRIPTION
## What does this change?

Change to allow install via web ui and drush on Drupal 11.2 without errors https://github.com/localgovdrupal/localgov_core/issues/307#issuecomment-3168498737