### PR TITLE
Make name field available for documents when adding/editing

### DIFF
--- a/modules/localgov_media/config/optional/core.entity_form_display.media.document.default.yml
+++ b/modules/localgov_media/config/optional/core.entity_form_display.media.document.default.yml
@@ -14,47 +14,47 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   field_media_document:
+    type: file_generic
+    weight: 1
+    region: content
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
-    type: file_generic
+  name:
+    type: string_textfield
     weight: 0
     region: content
-  langcode:
-    type: language_select
-    weight: 2
-    region: content
     settings:
-      include_locked: true
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   path:
     type: path
-    weight: 4
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
+    weight: 5
+    region: content
     settings:
       display_label: true
-    weight: 100
-    region: content
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 3
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
-    region: content
     third_party_settings: {  }
 hidden:
   moderation_state: true
-  name: true


### PR DESCRIPTION
Closes #295 

## What does this change?

Adds the "Name" field to the "Manage form display" field for documents, so then we can display this instead of the file-name when listing files.

Needs https://github.com/localgovdrupal/localgov_base/pull/849 to actually use the media name.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.