### PR TITLE
adds Microsites Base to themes array

### DIFF
--- a/src/Service/DefaultBlockInstaller.php
+++ b/src/Service/DefaultBlockInstaller.php
@@ -60,7 +60,7 @@ class DefaultBlockInstaller {
    */
   protected function targetThemes(): array {
 
-    $themes = ['localgov_base', 'localgov_scarfolk'];
+    $themes = ['localgov_base', 'localgov_scarfolk', 'localgov_microsites_base'];
 
     $activeTheme = $this->getActiveThemeName();
     if ($activeTheme && !in_array($activeTheme, $themes, TRUE)) {


### PR DESCRIPTION
Closes #323

## What does this change?

Adds `localgov_microsites_base` to themes array for block installer, so we don't have to add that config in `localgov_microsites_group` submodules.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.