### PR TITLE
adds unpublished items to linkit

### DIFF
--- a/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
+++ b/modules/localgov_media/config/optional/linkit.linkit_profile.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - localgov_core
     - node
     - paragraphs_library
 label: Default
@@ -17,7 +18,7 @@ matchers:
       group_by_bundle: true
       substitution_type: canonical
       limit: 100
-      include_unpublished: false
+      include_unpublished: true
     weight: -10
   c3257417-fce9-4307-8251-58672edf88be:
     id: email

--- a/src/Plugin/Linkit/Matcher/EntityMatcher.php
+++ b/src/Plugin/Linkit/Matcher/EntityMatcher.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\localgov_core\Plugin\Linkit\Matcher;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\linkit\Plugin\Linkit\Matcher\EntityMatcher as LinkitEntityMatcher;
+
+/**
+ * Provides default linkit matchers for all entity types.
+ *
+ * @Matcher(
+ *   id = "entity",
+ *   label = @Translation("Entity"),
+ *   deriver = "\Drupal\linkit\Plugin\Derivative\EntityMatcherDeriver"
+ * )
+ */
+class EntityMatcher extends LinkitEntityMatcher {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildLabel(EntityInterface $entity) {
+    $label = Html::escape($entity->label());
+
+    // Prepend "Unpublished: " for unpublished entities.
+    if (method_exists($entity, 'isPublished') && !$entity->isPublished()) {
+      $label = 'Unpublished: ' . $label;
+    }
+
+    return $label;
+  }
+
+}

--- a/src/Plugin/Linkit/Matcher/NodeMatcher.php
+++ b/src/Plugin/Linkit/Matcher/NodeMatcher.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\localgov_core\Plugin\Linkit\Matcher;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\linkit\Plugin\Linkit\Matcher\NodeMatcher as LinkitNodeMatcher;
+
+/**
+ * Provides specific linkit matchers for the node entity type.
+ *
+ * @Matcher(
+ *   id = "entity:node",
+ *   label = @Translation("Node"),
+ *   target_entity = "node",
+ *   provider = "node"
+ * )
+ */
+class NodeMatcher extends LinkitNodeMatcher {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildLabel(EntityInterface $entity) {
+    $label = Html::escape($entity->label());
+
+    // Prepend "Unpublished: " for unpublished nodes.
+    if (method_exists($entity, 'isPublished') && !$entity->isPublished()) {
+      $label = 'Unpublished: ' . $label;
+    }
+
+    return $label;
+  }
+
+}


### PR DESCRIPTION
Closes #334

## What does this change?

- Allows unpublished items to be linkit suggestions
- Adds "Unpublished: " before the title if it's unpublished.

## How to test
- Checkout this branch
- Clear your cache
- Make sure 'unpublished items' are allowed in the linkit matcher

## How can we measure success?

Content editors can create whole site sections without them being published.

## Images

<img width="555" height="555" alt="Screenshot 2025-12-01 at 12 15 24" src="https://github.com/user-attachments/assets/d5eabf17-5c22-4667-a9cd-bd52d7768a56" />

----
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.